### PR TITLE
Add persistent layer tree for overlay-aware retrieval

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,89 @@
+# Layers
+
+Witchcraft's layer model adds overlay-aware indexing on top of the basic
+document model. It is inspired by union/overlay filesystems (like OverlayFS):
+a read-only baseline holds the bulk of your data, and lightweight overlays
+capture deltas without copying the whole index.
+
+## When to use layers
+
+The basic document model (`add_doc` / `search`) is the right choice for most
+applications. Use layers when:
+
+- Your corpus is large and changes arrive as branch-scoped deltas (e.g., a
+  monorepo where each feature branch modifies a handful of files).
+- You need multiple concurrent views of the same index without duplicating it.
+- You want to expire stale views cheaply and revive them later.
+
+If your corpus fits comfortably in a single mutable index and you don't need
+branching, layers add complexity for no benefit. Stick with the basic model.
+
+For small-scale branching (2-3 concurrent views), querying separate database
+files is simpler and works fine. Layers pay off when the index is too large to
+duplicate: they share the embedding store and IVF globally, so overlays only
+store delta rows. Content-hash dedup means a branch that touches 50 files out
+of 100K shares 99.95% of embeddings with the baseline.
+
+## How it works
+
+A layer tree is a parent-pointer tree stored in the `layer` table. The typical
+topology is flat: one baseline (root) plus N overlay children.
+
+```
+baseline (mutable)
+├── overlay-branch-A
+├── overlay-branch-B
+└── overlay-branch-C
+```
+
+**Resolution**: when you query from an overlay's perspective, witchcraft walks
+the chain from overlay to root. The shallowest entry for each chunk wins.
+Tombstones in an overlay suppress baseline entries. For the common two-layer
+case this is a simple two-way dedup, not a recursive walk.
+
+**Lifecycle**: layers move through three statuses:
+- `active` -- accepting writes
+- `sealed` -- advisory immutability (application enforced)
+- `compacted` -- replaced by compaction output, pending cleanup
+
+## API
+
+```rust
+// Create a baseline
+let baseline = db.create_layer(None, "main", None)?;
+
+// Create an overlay for a branch
+let overlay = db.create_layer(Some(baseline), "feature/foo", Some(metadata_json))?;
+
+// Resolve the full chain (for query context)
+let chain = db.layer_chain(overlay)?;
+// chain.chain == [(overlay_id, 0), (baseline_id, 1)]
+
+// Freeze an overlay
+db.seal_layer(overlay)?;
+
+// Compact a deep sub-chain into a single layer
+let merged = db.compact_layers(leaf_id, Some(stop_at_id))?;
+
+// Clean up (fails if layer has children -- reparent or delete them first)
+db.delete_layer(overlay)?;
+```
+
+## Why a single mutable baseline
+
+For large corpora the index can be tens of gigabytes. Maintaining multiple
+baselines is not feasible. Instead, the baseline is mutated in place when the
+mainline source advances. Overlays automatically see baseline changes through
+layer resolution -- no rebasing needed unless the overlay and baseline modify
+the same content.
+
+Stale overlays are cheap to keep (only delta rows) and cheap to revive (most
+embeddings still exist in the content-addressed embedding store). Expiry policy
+is application-defined.
+
+## What layers don't do
+
+Layers are a structural primitive. They don't affect embedding, IVF indexing,
+or scoring. The IVF is global and layer-agnostic -- layer resolution is a
+post-filter after candidate retrieval. Ranking bias (recency, proximity,
+language preference) belongs in the application layer.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,8 @@
+use super::layer::{Layer, LayerChain, LayerError, LayerStatus};
 use super::types::SqlStatementInternal;
 use iso8601_timestamp::Timestamp;
 use log::{error, warn};
-use rusqlite::{params_from_iter, Connection, OpenFlags, Result as SQLResult, Statement};
+use rusqlite::{params, params_from_iter, Connection, OpenFlags, Result as SQLResult, Statement};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -143,6 +144,22 @@ impl DB {
         let query =
             "CREATE TABLE IF NOT EXISTS indexed_chunk(chunkid INTEGER PRIMARY KEY NOT NULL)";
         connection.execute(query, ())?;
+
+        // Layer tree for overlay-aware retrieval
+        connection.execute_batch(
+            "CREATE TABLE IF NOT EXISTS layer(
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent_id   INTEGER REFERENCES layer(id),
+                name        TEXT NOT NULL,
+                metadata    JSON,
+                created_at  TEXT NOT NULL,
+                status      TEXT NOT NULL DEFAULT 'active'
+                    CHECK(status IN ('active', 'sealed', 'compacted'))
+            );
+            CREATE INDEX IF NOT EXISTS layer_parent_index ON layer(parent_id);
+            CREATE INDEX IF NOT EXISTS layer_status_index ON layer(status);",
+        )?;
+
         Ok(Self {
             db_fn,
             connection: Some(connection),
@@ -155,6 +172,7 @@ impl DB {
         self.execute("DELETE FROM chunk")?;
         self.execute("DELETE FROM bucket")?;
         self.execute("DELETE FROM indexed_chunk")?;
+        self.execute("DELETE FROM layer")?;
         self.execute("VACUUM")?;
         Ok(())
     }
@@ -360,6 +378,261 @@ impl DB {
             (chunkid,),
         )?;
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer CRUD
+// ---------------------------------------------------------------------------
+impl DB {
+    fn read_layer(row: &rusqlite::Row) -> rusqlite::Result<Layer> {
+        let status_str: String = row.get(5)?;
+        let status: LayerStatus = match status_str.parse() {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("unknown layer status '{}': {}", status_str, e);
+                LayerStatus::Active
+            }
+        };
+        Ok(Layer {
+            id: row.get(0)?,
+            parent_id: row.get(1)?,
+            name: row.get(2)?,
+            metadata: row.get(3)?,
+            created_at: row.get(4)?,
+            status,
+        })
+    }
+
+    /// Create a new layer. Returns the layer ID.
+    pub fn create_layer(
+        &self,
+        parent_id: Option<i64>,
+        name: &str,
+        metadata: Option<&str>,
+    ) -> Result<i64, LayerError> {
+        let now = Timestamp::now_utc().to_string();
+        self.conn().execute(
+            "INSERT INTO layer(parent_id, name, metadata, created_at) VALUES(?1, ?2, ?3, ?4)",
+            params![parent_id, name, metadata, now],
+        )?;
+        Ok(self.conn().last_insert_rowid())
+    }
+
+    /// Seal a layer (mark immutable). Advisory — not enforced at the
+    /// SQL level, but the application should check before writing.
+    pub fn seal_layer(&self, layer_id: i64) -> Result<(), LayerError> {
+        let changed = self.conn().execute(
+            "UPDATE layer SET status = 'sealed' WHERE id = ?1 AND status = 'active'",
+            params![layer_id],
+        )?;
+        if changed == 0 {
+            // Distinguish not-found from not-active
+            return match self.get_layer(layer_id) {
+                Ok(_) => Err(LayerError::NotActive(layer_id)),
+                Err(_) => Err(LayerError::NotFound(layer_id)),
+            };
+        }
+        Ok(())
+    }
+
+    /// Get a single layer by ID.
+    pub fn get_layer(&self, layer_id: i64) -> Result<Layer, LayerError> {
+        self.conn()
+            .query_row(
+                "SELECT id, parent_id, name, metadata, created_at, status FROM layer WHERE id = ?1",
+                params![layer_id],
+                Self::read_layer,
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => LayerError::NotFound(layer_id),
+                other => LayerError::Sqlite(other),
+            })
+    }
+
+    /// Walk parent pointers from `layer_id` to root.
+    /// Returns a LayerChain with (layer_id, depth) pairs, depth 0 = the queried layer.
+    pub fn layer_chain(&self, layer_id: i64) -> Result<LayerChain, LayerError> {
+        let mut stmt = self.conn().prepare(
+            "WITH RECURSIVE chain(id, parent_id, depth) AS (
+                SELECT id, parent_id, 0 FROM layer WHERE id = ?1
+                UNION ALL
+                SELECT l.id, l.parent_id, c.depth + 1
+                FROM chain c
+                JOIN layer l ON l.id = c.parent_id
+            )
+            SELECT id, depth FROM chain ORDER BY depth",
+        )?;
+        let chain: Vec<(i64, u32)> = stmt
+            .query_map(params![layer_id], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, u32>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        if chain.is_empty() {
+            return Err(LayerError::NotFound(layer_id));
+        }
+        Ok(LayerChain { chain })
+    }
+
+    /// Direct children of a layer.
+    pub fn layer_children(&self, layer_id: i64) -> Result<Vec<Layer>, LayerError> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, parent_id, name, metadata, created_at, status
+             FROM layer WHERE parent_id = ?1 ORDER BY id",
+        )?;
+        let layers = stmt
+            .query_map(params![layer_id], Self::read_layer)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(layers)
+    }
+
+    /// All layers in the tree.
+    pub fn layer_tree(&self) -> Result<Vec<Layer>, LayerError> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, parent_id, name, metadata, created_at, status FROM layer ORDER BY id",
+        )?;
+        let layers = stmt
+            .query_map((), Self::read_layer)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(layers)
+    }
+
+    /// Delete a layer. Fails if the layer has children
+    /// (caller must reparent or delete children first).
+    pub fn delete_layer(&self, layer_id: i64) -> Result<(), LayerError> {
+        let child_count: i64 = self.conn().query_row(
+            "SELECT COUNT(*) FROM layer WHERE parent_id = ?1",
+            params![layer_id],
+            |row| row.get(0),
+        )?;
+        if child_count > 0 {
+            return Err(LayerError::HasChildren(layer_id));
+        }
+        let changed = self
+            .conn()
+            .execute("DELETE FROM layer WHERE id = ?1", params![layer_id])?;
+        if changed == 0 {
+            return Err(LayerError::NotFound(layer_id));
+        }
+        Ok(())
+    }
+
+    /// Reparent a layer to a new parent. Private — only used by compact_layers
+    /// to avoid exposing an API that could create cycles.
+    fn reparent_layer(
+        &self,
+        layer_id: i64,
+        new_parent_id: Option<i64>,
+    ) -> Result<(), LayerError> {
+        let changed = self.conn().execute(
+            "UPDATE layer SET parent_id = ?1 WHERE id = ?2",
+            params![new_parent_id, layer_id],
+        )?;
+        if changed == 0 {
+            return Err(LayerError::NotFound(layer_id));
+        }
+        Ok(())
+    }
+
+    /// Compact: merge the chain from `layer_id` up to (but not including)
+    /// `stop_at` into a single new layer. Reparent children of merged layers
+    /// to the new layer. Mark compacted layers as `compacted`.
+    /// Returns the new layer's ID.
+    ///
+    /// Chunk data migration is added in PR 2.
+    pub fn compact_layers(
+        &self,
+        layer_id: i64,
+        stop_at: Option<i64>,
+    ) -> Result<i64, LayerError> {
+        // Walk the chain from layer_id up to stop_at
+        let full_chain = self.layer_chain(layer_id)?;
+
+        // Validate that stop_at is actually in the chain
+        if let Some(stop) = stop_at {
+            if !full_chain.chain.iter().any(|&(id, _)| id == stop) {
+                return Err(LayerError::NotInChain {
+                    stop_at: stop,
+                    layer_id,
+                });
+            }
+        }
+
+        let mut to_compact: Vec<i64> = Vec::new();
+        for &(id, _depth) in &full_chain.chain {
+            if Some(id) == stop_at {
+                break;
+            }
+            to_compact.push(id);
+        }
+        if to_compact.is_empty() {
+            // layer_id == stop_at: nothing to compact
+            return Err(LayerError::NotInChain {
+                stop_at: stop_at.unwrap(),
+                layer_id,
+            });
+        }
+
+        // The new layer's parent is either stop_at or the parent of the
+        // last layer in the compaction chain (the next entry after it
+        // in the depth-ordered chain).
+        let new_parent = stop_at.or_else(|| {
+            let last = *to_compact.last().unwrap();
+            let last_pos = full_chain
+                .chain
+                .iter()
+                .position(|&(id, _)| id == last)
+                .unwrap();
+            full_chain.chain.get(last_pos + 1).map(|&(id, _)| id)
+        });
+
+        self.begin_transaction()
+            .map_err(|e| LayerError::Sqlite(e))?;
+
+        let result = (|| -> Result<i64, LayerError> {
+            // Create the compacted layer
+            let leaf = self.get_layer(layer_id)?;
+            let compacted_id = self.create_layer(
+                new_parent,
+                &format!("compacted:{}", leaf.name),
+                None,
+            )?;
+
+            // Reparent children of all compacted layers to the new layer
+            // (excluding the compacted layers themselves)
+            for &id in &to_compact {
+                let children = self.layer_children(id)?;
+                for child in children {
+                    if !to_compact.contains(&child.id) {
+                        self.reparent_layer(child.id, Some(compacted_id))?;
+                    }
+                }
+            }
+
+            // Mark compacted layers
+            for &id in &to_compact {
+                self.conn().execute(
+                    "UPDATE layer SET status = 'compacted' WHERE id = ?1",
+                    params![id],
+                )?;
+            }
+
+            Ok(compacted_id)
+        })();
+
+        match &result {
+            Ok(_) => {
+                self.commit_transaction()
+                    .map_err(|e| LayerError::Sqlite(e))?;
+            }
+            Err(_) => {
+                if let Err(e) = self.rollback_transaction() {
+                    error!("rollback failed during compact_layers: {e}");
+                }
+            }
+        }
+
+        result
     }
 }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,0 +1,95 @@
+use std::fmt;
+
+/// Errors specific to layer operations.
+#[derive(Debug)]
+pub enum LayerError {
+    NotFound(i64),
+    HasChildren(i64),
+    NotActive(i64),
+    /// stop_at is not an ancestor of the compaction source layer
+    NotInChain { stop_at: i64, layer_id: i64 },
+    Sqlite(rusqlite::Error),
+}
+
+impl fmt::Display for LayerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LayerError::NotFound(id) => write!(f, "layer {id} not found"),
+            LayerError::HasChildren(id) => write!(f, "layer {id} has children"),
+            LayerError::NotActive(id) => write!(f, "layer {id} is not active"),
+            LayerError::NotInChain { stop_at, layer_id } => {
+                write!(f, "layer {stop_at} is not an ancestor of {layer_id}")
+            }
+            LayerError::Sqlite(e) => write!(f, "sqlite error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LayerError {}
+
+impl From<rusqlite::Error> for LayerError {
+    fn from(e: rusqlite::Error) -> Self {
+        LayerError::Sqlite(e)
+    }
+}
+
+/// Layer status in the persistent tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerStatus {
+    /// Accepting writes.
+    Active,
+    /// Immutable (advisory — application enforced, not IVF-driven).
+    Sealed,
+    /// Replaced by compaction output, pending GC.
+    Compacted,
+}
+
+impl LayerStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LayerStatus::Active => "active",
+            LayerStatus::Sealed => "sealed",
+            LayerStatus::Compacted => "compacted",
+        }
+    }
+}
+
+impl std::str::FromStr for LayerStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(LayerStatus::Active),
+            "sealed" => Ok(LayerStatus::Sealed),
+            "compacted" => Ok(LayerStatus::Compacted),
+            other => Err(format!("unknown layer status: {other}")),
+        }
+    }
+}
+
+impl fmt::Display for LayerStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A layer in the persistent tree.
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub id: i64,
+    pub parent_id: Option<i64>,
+    pub name: String,
+    pub metadata: Option<String>,
+    pub created_at: String,
+    pub status: LayerStatus,
+}
+
+/// Identifies a position in the layer tree for query resolution.
+/// For the common flat case (overlay + baseline), this is just two IDs.
+#[derive(Debug, Clone)]
+pub struct LayerChain {
+    /// Layer IDs from leaf to root, with depth indices.
+    /// For flat topology: [(overlay_id, 0), (baseline_id, 1)]
+    /// For baseline-only: [(baseline_id, 0)]
+    pub chain: Vec<(i64, u32)>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ compile_error!("hybrid-dequant is incompatible with metal (use accelerate only f
 mod db;
 pub use db::DB;
 
+pub mod layer;
+pub use layer::{Layer, LayerChain, LayerError, LayerStatus};
+
 mod embedder;
 pub use embedder::Embedder;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,268 @@
 #[cfg(test)]
+mod layer_tests {
+    use crate::layer::{LayerError, LayerStatus};
+    use crate::DB;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+    use test_log::test;
+
+    fn make_db() -> (DB, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let path: PathBuf = dir.path().join("test.db");
+        let db = DB::new(path).unwrap();
+        (db, dir)
+    }
+
+    #[test]
+    fn test_flat_topology_chain() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "overlay-a", None).unwrap();
+        let b = db.create_layer(Some(root), "overlay-b", None).unwrap();
+
+        let chain_a = db.layer_chain(a).unwrap();
+        assert_eq!(chain_a.chain, vec![(a, 0), (root, 1)]);
+
+        let chain_b = db.layer_chain(b).unwrap();
+        assert_eq!(chain_b.chain, vec![(b, 0), (root, 1)]);
+
+        let chain_root = db.layer_chain(root).unwrap();
+        assert_eq!(chain_root.chain, vec![(root, 0)]);
+    }
+
+    #[test]
+    fn test_deep_topology_chain() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let a1 = db.create_layer(Some(a), "a1", None).unwrap();
+
+        let chain = db.layer_chain(a1).unwrap();
+        assert_eq!(chain.chain, vec![(a1, 0), (a, 1), (root, 2)]);
+    }
+
+    #[test]
+    fn test_seal_layer() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+
+        db.seal_layer(root).unwrap();
+        let layer = db.get_layer(root).unwrap();
+        assert_eq!(layer.status, LayerStatus::Sealed);
+
+        // Sealing again should fail with NotActive
+        assert!(matches!(db.seal_layer(root), Err(LayerError::NotActive(_))));
+    }
+
+    #[test]
+    fn test_seal_nonexistent() {
+        let (db, _dir) = make_db();
+        assert!(matches!(db.seal_layer(999), Err(LayerError::NotFound(999))));
+    }
+
+    #[test]
+    fn test_layer_children() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let b = db.create_layer(Some(root), "b", None).unwrap();
+
+        let children = db.layer_children(root).unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].id, a);
+        assert_eq!(children[1].id, b);
+
+        let leaf_children = db.layer_children(a).unwrap();
+        assert!(leaf_children.is_empty());
+    }
+
+    #[test]
+    fn test_layer_tree() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let _a = db.create_layer(Some(root), "a", None).unwrap();
+        let _b = db.create_layer(Some(root), "b", None).unwrap();
+
+        let tree = db.layer_tree().unwrap();
+        assert_eq!(tree.len(), 3);
+    }
+
+    #[test]
+    fn test_delete_leaf() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+
+        db.delete_layer(a).unwrap();
+        let tree = db.layer_tree().unwrap();
+        assert_eq!(tree.len(), 1);
+    }
+
+    #[test]
+    fn test_delete_with_children_fails() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let _a = db.create_layer(Some(root), "a", None).unwrap();
+
+        assert!(matches!(db.delete_layer(root), Err(LayerError::HasChildren(_))));
+    }
+
+    #[test]
+    fn test_compact_reparents_via_compaction() {
+        // reparent_layer is private; verify reparenting works through compact_layers
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let b = db.create_layer(Some(a), "b", None).unwrap();
+        // b has a child that should be reparented to the compacted layer
+        let c = db.create_layer(Some(b), "c", None).unwrap();
+
+        let compacted = db.compact_layers(b, Some(root)).unwrap();
+
+        // c was reparented to the compacted layer
+        let child = db.get_layer(c).unwrap();
+        assert_eq!(child.parent_id, Some(compacted));
+
+        // Compacted layer's chain goes through root
+        let chain = db.layer_chain(compacted).unwrap();
+        assert_eq!(chain.chain, vec![(compacted, 0), (root, 1)]);
+    }
+
+    #[test]
+    fn test_compact_sub_chain() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let a1 = db.create_layer(Some(a), "a1", None).unwrap();
+        let a1_child = db.create_layer(Some(a1), "a1-child", None).unwrap();
+
+        let compacted = db.compact_layers(a1, Some(root)).unwrap();
+
+        assert_eq!(db.get_layer(a1).unwrap().status, LayerStatus::Compacted);
+        assert_eq!(db.get_layer(a).unwrap().status, LayerStatus::Compacted);
+
+        let compacted_layer = db.get_layer(compacted).unwrap();
+        assert_eq!(compacted_layer.parent_id, Some(root));
+        assert_eq!(compacted_layer.status, LayerStatus::Active);
+
+        let child = db.get_layer(a1_child).unwrap();
+        assert_eq!(child.parent_id, Some(compacted));
+    }
+
+    #[test]
+    fn test_compact_full_chain_stop_at_none() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let a1 = db.create_layer(Some(a), "a1", None).unwrap();
+
+        // Compact entire chain (stop_at = None): a1 → a → root
+        let compacted = db.compact_layers(a1, None).unwrap();
+
+        // All three original layers are marked compacted
+        assert_eq!(db.get_layer(a1).unwrap().status, LayerStatus::Compacted);
+        assert_eq!(db.get_layer(a).unwrap().status, LayerStatus::Compacted);
+        assert_eq!(db.get_layer(root).unwrap().status, LayerStatus::Compacted);
+
+        // New layer has no parent (it's the new root)
+        let compacted_layer = db.get_layer(compacted).unwrap();
+        assert_eq!(compacted_layer.parent_id, None);
+    }
+
+    #[test]
+    fn test_compact_single_layer() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+
+        // Compact root alone (stop_at = None, chain = [root])
+        let compacted = db.compact_layers(root, None).unwrap();
+
+        assert_eq!(db.get_layer(root).unwrap().status, LayerStatus::Compacted);
+
+        let compacted_layer = db.get_layer(compacted).unwrap();
+        assert_eq!(compacted_layer.parent_id, None);
+        assert_eq!(compacted_layer.status, LayerStatus::Active);
+    }
+
+    #[test]
+    fn test_clear_removes_layers() {
+        let (mut db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let _a = db.create_layer(Some(root), "a", None).unwrap();
+
+        db.clear();
+        // Recreate after clear (clear sets remove_on_shutdown but also deletes rows)
+        let tree = db.layer_tree().unwrap();
+        assert!(tree.is_empty());
+    }
+
+    #[test]
+    fn test_metadata() {
+        let (db, _dir) = make_db();
+        let meta = r#"{"branch":"feature/foo","commit":"abc123"}"#;
+        let id = db.create_layer(None, "baseline", Some(meta)).unwrap();
+        let layer = db.get_layer(id).unwrap();
+        assert_eq!(layer.metadata.as_deref(), Some(meta));
+    }
+
+    #[test]
+    fn test_nonexistent_layer_chain() {
+        let (db, _dir) = make_db();
+        assert!(matches!(db.layer_chain(999), Err(LayerError::NotFound(999))));
+    }
+
+    #[test]
+    fn test_delete_nonexistent() {
+        let (db, _dir) = make_db();
+        assert!(matches!(db.delete_layer(999), Err(LayerError::NotFound(999))));
+    }
+
+    #[test]
+    fn test_compact_invalid_stop_at() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+        let b = db.create_layer(Some(root), "b", None).unwrap();
+
+        // b is not an ancestor of a — should fail
+        assert!(matches!(
+            db.compact_layers(a, Some(b)),
+            Err(LayerError::NotInChain { .. })
+        ));
+    }
+
+    #[test]
+    fn test_compact_self_stop_at() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let a = db.create_layer(Some(root), "a", None).unwrap();
+
+        // compact(a, Some(a)) — zero layers to compact
+        assert!(matches!(
+            db.compact_layers(a, Some(a)),
+            Err(LayerError::NotInChain { .. })
+        ));
+    }
+
+    #[test]
+    fn test_error_variants_are_distinguishable() {
+        let (db, _dir) = make_db();
+        let root = db.create_layer(None, "baseline", None).unwrap();
+        let _child = db.create_layer(Some(root), "child", None).unwrap();
+
+        // HasChildren vs NotFound on delete
+        assert!(matches!(db.delete_layer(root), Err(LayerError::HasChildren(_))));
+        assert!(matches!(db.delete_layer(999), Err(LayerError::NotFound(999))));
+
+        // NotActive vs NotFound on seal
+        let leaf = db.create_layer(Some(root), "leaf", None).unwrap();
+        db.seal_layer(leaf).unwrap();
+        assert!(matches!(db.seal_layer(leaf), Err(LayerError::NotActive(_))));
+        assert!(matches!(db.seal_layer(999), Err(LayerError::NotFound(999))));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::DB;
     use std::path::PathBuf;


### PR DESCRIPTION
### Motivation

Witchcraft needs overlay-aware indexing for use cases where a large corpus has concurrent branch-scoped views (e.g., a monorepo where feature branches modify a handful of files). The basic document model requires duplicating the entire index per view, which is infeasible at scale. The layer model adds a lightweight structural primitive (inspired by OverlayFS and Clojure's persistent data structures) that lets overlays store only deltas while sharing the embedding store and IVF globally.

### Changes

- src/layer.rs (new) — LayerStatus enum (Active/Sealed/Compacted), Layer struct, LayerChain for query resolution, LayerError for distinguishable error variants (NotFound, HasChildren, NotActive, NotInChain).
- src/db.rs — layer table DDL (parent-pointer tree with status CHECK constraint, parent/status indices). Layer CRUD: create_layer, seal_layer, get_layer,  layer_chain (recursive CTE), layer_children, layer_tree, delete_layer (refuses with children), compact_layers (transactional, validates stop_at ancestry,  reparents orphaned children).
- src/lib.rs — Wires pub mod layer and re-exports types.
- docs/layers.md (new) — User-facing documentation: when to use layers vs the basic model vs separate databases, API examples, design rationale.
- src/tests.rs — 19 tests covering flat/deep topology chain resolution, seal with error variants, compaction edge cases (sub-chain, full chain, single layer,  invalid/self stop_at), reparenting via compaction, clear, metadata round-trip, and error distinguishability.

No changes to the existing document path. No schema version bump (additive CREATE TABLE IF NOT EXISTS).

### Test plan

- 19 layer-specific tests passing
- All 36 fast tests pass (existing document-path tests unaffected)
- Full test suite including embedding-dependent tests