### PR TITLE
pickbrain branch support

### DIFF
--- a/examples/pickbrain/claude_code.rs
+++ b/examples/pickbrain/claude_code.rs
@@ -24,6 +24,11 @@ struct SessionEntry {
     entry_type: String,
     timestamp: Option<String>,
     message: Option<Message>,
+    #[serde(rename = "gitBranch")]
+    git_branch: Option<String>,
+    #[serde(rename = "customTitle")]
+    custom_title: Option<String>,
+    cwd: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -64,6 +69,7 @@ struct Chunk {
     ts_ms: i64,
     byte_offset: u64,
     byte_len: u64,
+    git_branch: Option<String>,
 }
 
 fn codepoint_len(s: &str) -> usize {
@@ -168,13 +174,19 @@ fn compact(text: &str) -> String {
     re.replace_all(text, " ").trim().to_string()
 }
 
-fn parse_session_file(path: &Path) -> Vec<Chunk> {
+struct SessionInfo {
+    custom_title: Option<String>,
+    cwd: Option<String>,
+}
+
+fn parse_session_file(path: &Path) -> (SessionInfo, Vec<Chunk>) {
     let raw = match fs::read_to_string(path) {
         Ok(s) => s,
-        Err(_) => return vec![],
+        Err(_) => return (SessionInfo { custom_title: None, cwd: None }, vec![]),
     };
 
     let mut chunks = Vec::new();
+    let mut info = SessionInfo { custom_title: None, cwd: None };
     let mut offset: u64 = 0;
 
     for line in raw.lines() {
@@ -188,6 +200,21 @@ fn parse_session_file(path: &Path) -> Vec<Chunk> {
             Ok(e) => e,
             Err(_) => continue,
         };
+
+        if entry.entry_type == "custom-title" {
+            if let Some(ref title) = entry.custom_title {
+                info.custom_title = Some(title.clone());
+            }
+            continue;
+        }
+
+        // Use the cwd from JSONL entries (authoritative) rather than decoding
+        // from the directory name, which is ambiguous when paths contain dashes.
+        if info.cwd.is_none() {
+            if let Some(ref cwd) = entry.cwd {
+                info.cwd = Some(cwd.clone());
+            }
+        }
 
         if entry.entry_type != "user" && entry.entry_type != "assistant" {
             continue;
@@ -243,11 +270,12 @@ fn parse_session_file(path: &Path) -> Vec<Chunk> {
             ts_ms,
             byte_offset: line_offset,
             byte_len: line.len() as u64,
+            git_branch: entry.git_branch,
         });
     }
 
     chunks.sort_by_key(|c| c.ts_ms);
-    chunks
+    (info, chunks)
 }
 
 fn decode_project_name(dir_name: &str) -> String {
@@ -255,19 +283,29 @@ fn decode_project_name(dir_name: &str) -> String {
 }
 
 fn ingest_session(db: &mut DB, path: &Path, project_name: &str, mtime_ms: i64) -> Result<usize> {
-    let chunks = parse_session_file(path);
+    let (info, chunks) = parse_session_file(path);
     if chunks.is_empty() {
         return Ok(0);
     }
 
+    // Prefer the cwd from inside the JSONL (authoritative) over the decoded
+    // directory name, which is lossy when paths contain dashes.
+    let project_name = info
+        .cwd
+        .as_deref()
+        .map(|cwd| cwd.trim_start_matches('/').to_string())
+        .unwrap_or_else(|| project_name.to_string());
+
     let session_id = path.file_stem().unwrap().to_string_lossy();
 
-    // Session title: first user message of the entire session
-    let session_title: String = chunks
-        .iter()
-        .find(|c| c.role == "user")
-        .map(|c| c.text.chars().take(240).collect())
-        .unwrap_or_default();
+    // Session title: custom name if set, otherwise first user message
+    let session_title: String = info.custom_title.unwrap_or_else(|| {
+        chunks
+            .iter()
+            .find(|c| c.role == "user")
+            .map(|c| c.text.chars().take(240).collect())
+            .unwrap_or_default()
+    });
 
     // Split into interactions: each starts at a user message
     let mut interactions: Vec<&[Chunk]> = Vec::new();
@@ -315,13 +353,21 @@ fn ingest_session(db: &mut DB, path: &Path, project_name: &str, mtime_ms: i64) -
             format!("{session_id}:{turn_idx}").as_bytes(),
         );
 
+        let branch: Option<&str> = interaction
+            .iter()
+            .filter_map(|c| c.git_branch.as_deref())
+            .last();
+
         let metadata = serde_json::json!({
             "project": project_name,
             "session_id": session_id.to_string(),
+            "session_name": session_title,
             "turn": turn_idx,
             "path": path.to_string_lossy(),
+            "cwd": info.cwd,
             "mtime_ms": mtime_ms,
             "turns": turns_meta,
+            "branch": branch,
         })
         .to_string();
 
@@ -680,6 +726,162 @@ pub fn ingest_claude_code(db: &mut DB) -> Result<(usize, usize, usize, usize)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    fn write_tempfile(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    fn jsonl_line(entry_type: &str, role: &str, text: &str, ts: &str, branch: Option<&str>, cwd: Option<&str>) -> String {
+        let msg = serde_json::json!({
+            "role": role,
+            "content": text,
+        });
+        let mut entry = serde_json::json!({
+            "type": entry_type,
+            "timestamp": ts,
+            "message": msg,
+        });
+        if let Some(b) = branch {
+            entry["gitBranch"] = serde_json::Value::String(b.to_string());
+        }
+        if let Some(c) = cwd {
+            entry["cwd"] = serde_json::Value::String(c.to_string());
+        }
+        serde_json::to_string(&entry).unwrap()
+    }
+
+    // -- sanitize tests --
+
+    #[test]
+    fn test_sanitize_strips_code_and_compacts() {
+        let input = "Hello ```rust\nfn main() {}\n``` world  and  `inline`  code";
+        let result = sanitize(input);
+        assert_eq!(result, "Hello world and code");
+    }
+
+    #[test]
+    fn test_sanitize_strips_system_xml() {
+        let input = "Before <system-reminder>secret stuff</system-reminder> after";
+        let result = sanitize(input);
+        assert_eq!(result, "Before after");
+    }
+
+    #[test]
+    fn test_sanitize_strips_tables() {
+        let input = "Header\n| col1 | col2 |\n| --- | --- |\n| a | b |\nFooter";
+        let result = sanitize(input);
+        // strip_tables removes table rows, compact collapses multi-whitespace
+        // but a single \n between Header and Footer doesn't trigger compaction
+        assert!(!result.contains("col1"));
+        assert!(result.contains("Header"));
+        assert!(result.contains("Footer"));
+    }
+
+    #[test]
+    fn test_sanitize_strips_interrupted_and_continuation() {
+        assert_eq!(
+            sanitize("Hello [Request interrupted by user] world"),
+            "Hello world"
+        );
+        assert_eq!(
+            sanitize("Keep this. This session is being continued from a previous conversation and more"),
+            "Keep this."
+        );
+    }
+
+    // -- parse_session_file tests --
+
+    #[test]
+    fn test_parse_extracts_custom_title() {
+        let content = format!(
+            "{}\n{}\n",
+            r#"{"type":"custom-title","customTitle":"My Title"}"#,
+            jsonl_line("user", "user", "hello world test message", "2025-01-15T10:00:00Z", None, None),
+        );
+        let f = write_tempfile(&content);
+        let (info, chunks) = parse_session_file(f.path());
+        assert_eq!(info.custom_title.as_deref(), Some("My Title"));
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].role, "user");
+    }
+
+    #[test]
+    fn test_parse_extracts_cwd() {
+        let content = format!(
+            "{}\n",
+            jsonl_line("user", "user", "hello world test message", "2025-01-15T10:00:00Z", None, Some("/Users/me/src/dash-search-debugger")),
+        );
+        let f = write_tempfile(&content);
+        let (info, _) = parse_session_file(f.path());
+        assert_eq!(info.cwd.as_deref(), Some("/Users/me/src/dash-search-debugger"));
+    }
+
+    #[test]
+    fn test_parse_last_branch_wins() {
+        let content = format!(
+            "{}\n{}\n{}\n",
+            jsonl_line("user", "user", "first user message here", "2025-01-15T10:00:00Z", Some("branch-a"), None),
+            jsonl_line("assistant", "assistant", "first assistant response here", "2025-01-15T10:01:00Z", Some("branch-b"), None),
+            jsonl_line("user", "user", "second user message here", "2025-01-15T10:02:00Z", Some("branch-c"), None),
+        );
+        let f = write_tempfile(&content);
+        let (_, chunks) = parse_session_file(f.path());
+        assert_eq!(chunks.len(), 3);
+        // Last chunk has branch-c
+        assert_eq!(chunks[2].git_branch.as_deref(), Some("branch-c"));
+        // The last branch in the full sequence is branch-c
+        let last_branch = chunks.iter().filter_map(|c| c.git_branch.as_deref()).last();
+        assert_eq!(last_branch, Some("branch-c"));
+    }
+
+    #[test]
+    fn test_parse_skips_short_and_long_text() {
+        let short = "hi"; // < MIN_CHUNK_CODEPOINTS
+        let long = "x".repeat(MAX_CHUNK_CODEPOINTS + 1);
+        let ok = "this is a valid chunk of text";
+        let content = format!(
+            "{}\n{}\n{}\n",
+            jsonl_line("user", "user", short, "2025-01-15T10:00:00Z", None, None),
+            jsonl_line("user", "user", &long, "2025-01-15T10:01:00Z", None, None),
+            jsonl_line("user", "user", ok, "2025-01-15T10:02:00Z", None, None),
+        );
+        let f = write_tempfile(&content);
+        let (_, chunks) = parse_session_file(f.path());
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].text.contains("valid chunk"));
+    }
+
+    #[test]
+    fn test_parse_empty_file() {
+        let f = write_tempfile("");
+        let (info, chunks) = parse_session_file(f.path());
+        assert!(info.custom_title.is_none());
+        assert!(info.cwd.is_none());
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn test_parse_nonexistent_file() {
+        let (info, chunks) = parse_session_file(Path::new("/nonexistent/file.jsonl"));
+        assert!(info.custom_title.is_none());
+        assert!(chunks.is_empty());
+    }
+
+    // -- decode_project_name tests --
+
+    #[test]
+    fn test_decode_project_name() {
+        assert_eq!(decode_project_name("-Users-eider-src-server"), "Users/eider/src/server");
+        // Ambiguous: dashes in the actual path
+        assert_eq!(
+            decode_project_name("-Users-eider-src-dash-search-debugger"),
+            "Users/eider/src/dash/search/debugger"
+        );
+    }
 
     #[test]
     fn test_split_markdown_no_bare_headings() {

--- a/examples/pickbrain/codex.rs
+++ b/examples/pickbrain/codex.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use once_cell::sync::Lazy;
 use uuid::Uuid;
 
 use witchcraft::DB;
@@ -90,13 +91,42 @@ fn extract_reasoning_text(payload: &serde_json::Value) -> Option<String> {
     payload.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())
 }
 
-fn parse_session_file(path: &Path) -> (Option<String>, Vec<Chunk>) {
+/// Extract a branch name from git checkout/switch output in exec command results.
+/// Matches patterns like:
+///   "Switched to a new branch 'foo'"
+///   "Switched to branch 'foo'"
+///   "Already on 'foo'"
+///
+/// TODO: git's single-quote format isn't guaranteed across versions/locales.
+/// Covers all standard English git output; revisit if we hit edge cases.
+static BRANCH_SWITCH_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?:Switched to (?:a new )?branch|Already on) '([^']+)'").unwrap()
+});
+
+fn extract_branch_from_output(payload: &serde_json::Value) -> Option<String> {
+    let ty = payload.get("type")?.as_str()?;
+    if ty != "function_call_output" {
+        return None;
+    }
+    let output = payload.get("output")?.as_str()?;
+    BRANCH_SWITCH_RE
+        .captures(output)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+struct SessionMeta {
+    cwd: Option<String>,
+    branch: Option<String>,
+}
+
+fn parse_session_file(path: &Path) -> (SessionMeta, Vec<Chunk>) {
     let raw = match fs::read_to_string(path) {
         Ok(s) => s,
-        Err(_) => return (None, vec![]),
+        Err(_) => return (SessionMeta { cwd: None, branch: None }, vec![]),
     };
 
-    let mut cwd = None;
+    let mut meta = SessionMeta { cwd: None, branch: None };
     let mut chunks = Vec::new();
     let mut offset: u64 = 0;
 
@@ -112,10 +142,25 @@ fn parse_session_file(path: &Path) -> (Option<String>, Vec<Chunk>) {
         };
 
         if entry.entry_type == "session_meta" {
-            if cwd.is_none() {
-                cwd = entry.payload.get("cwd").and_then(|c| c.as_str()).map(|s| s.to_string());
+            if meta.cwd.is_none() {
+                meta.cwd = entry.payload.get("cwd").and_then(|c| c.as_str()).map(|s| s.to_string());
+            }
+            // Only set from session_meta if no branch seen yet — exec output
+            // overwrites unconditionally below, so the last checkout always wins.
+            if meta.branch.is_none() {
+                meta.branch = entry.payload
+                    .get("git")
+                    .and_then(|g| g.get("branch"))
+                    .and_then(|b| b.as_str())
+                    .map(|s| s.to_string());
             }
             continue;
+        }
+
+        // Detect branch changes from git checkout/switch in exec output.
+        // Unconditional overwrite: the last branch switch in the session wins.
+        if let Some(switched) = extract_branch_from_output(&entry.payload) {
+            meta.branch = Some(switched);
         }
 
         let timestamp = match &entry.timestamp {
@@ -165,7 +210,7 @@ fn parse_session_file(path: &Path) -> (Option<String>, Vec<Chunk>) {
     }
 
     chunks.sort_by_key(|c| c.ts_ms);
-    (cwd, chunks)
+    (meta, chunks)
 }
 
 fn project_from_cwd(cwd: &str) -> String {
@@ -188,20 +233,27 @@ fn session_id_from_filename(path: &Path) -> String {
     stem.to_string()
 }
 
-fn ingest_session(db: &mut DB, path: &Path, mtime_ms: i64) -> Result<usize> {
-    let (cwd, chunks) = parse_session_file(path);
+fn ingest_session(
+    db: &mut DB,
+    path: &Path,
+    mtime_ms: i64,
+    session_name: Option<&str>,
+) -> Result<usize> {
+    let (meta, chunks) = parse_session_file(path);
     if chunks.is_empty() {
         return Ok(0);
     }
 
-    let project_name = cwd.as_deref().map(project_from_cwd).unwrap_or_default();
+    let project_name = meta.cwd.as_deref().map(project_from_cwd).unwrap_or_default();
     let session_id = session_id_from_filename(path);
 
-    let session_title: String = chunks
-        .iter()
-        .find(|c| c.role == "user")
-        .map(|c| c.text.chars().take(240).collect())
-        .unwrap_or_default();
+    let session_title: String = session_name.map(|s| s.to_string()).unwrap_or_else(|| {
+        chunks
+            .iter()
+            .find(|c| c.role == "user")
+            .map(|c| c.text.chars().take(240).collect())
+            .unwrap_or_default()
+    });
 
     // Split into interactions starting at each user message
     let mut interactions: Vec<&[Chunk]> = Vec::new();
@@ -251,11 +303,13 @@ fn ingest_session(db: &mut DB, path: &Path, mtime_ms: i64) -> Result<usize> {
             "source": "codex",
             "project": project_name,
             "session_id": session_id,
+            "session_name": session_title,
             "turn": turn_idx,
             "path": path.to_string_lossy(),
-            "cwd": cwd,
+            "cwd": meta.cwd,
             "mtime_ms": mtime_ms,
             "turns": turns_meta,
+            "branch": meta.branch,
         })
         .to_string();
 
@@ -301,6 +355,27 @@ fn collect_session_files(base: &Path) -> Vec<PathBuf> {
     files
 }
 
+fn load_session_index() -> std::collections::HashMap<String, String> {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let index_path = PathBuf::from(&home).join(".codex/session_index.jsonl");
+    let mut names = std::collections::HashMap::new();
+    let raw = match fs::read_to_string(&index_path) {
+        Ok(s) => s,
+        Err(_) => return names,
+    };
+    for line in raw.lines() {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if let (Some(id), Some(name)) = (
+                v.get("id").and_then(|i| i.as_str()),
+                v.get("thread_name").and_then(|n| n.as_str()),
+            ) {
+                names.insert(id.to_string(), name.to_string());
+            }
+        }
+    }
+    names
+}
+
 pub fn ingest_codex(db: &mut DB) -> Result<usize> {
     let home = std::env::var("HOME").unwrap_or_default();
     let sessions_dir = PathBuf::from(&home).join(".codex/sessions");
@@ -309,6 +384,7 @@ pub fn ingest_codex(db: &mut DB) -> Result<usize> {
         return Ok(0);
     }
 
+    let session_names = load_session_index();
     let wm_path = watermark::codex_path();
     let wm_ts = watermark::mtime_ms(&wm_path);
     let mut session_count = 0usize;
@@ -318,8 +394,10 @@ pub fn ingest_codex(db: &mut DB) -> Result<usize> {
             continue;
         }
         let mtime_ms = file_mtime_ms(&jsonl_path).unwrap_or(0);
+        let sid = session_id_from_filename(&jsonl_path);
+        let name = session_names.get(&sid).map(|s| s.as_str());
         println!("{}", jsonl_path.display());
-        match ingest_session(db, &jsonl_path, mtime_ms) {
+        match ingest_session(db, &jsonl_path, mtime_ms, name) {
             Ok(n) => session_count += n,
             Err(e) => {
                 log::warn!("failed to ingest codex {}: {e}", jsonl_path.display());
@@ -329,4 +407,180 @@ pub fn ingest_codex(db: &mut DB) -> Result<usize> {
 
     watermark::touch(&wm_path);
     Ok(session_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tempfile(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    // -- extract_branch_from_output tests --
+
+    #[test]
+    fn test_extract_branch_from_output() {
+        let cases = vec![
+            // (output text, expected branch)
+            ("Switched to a new branch 'feature/foo'", Some("feature/foo")),
+            ("Switched to branch 'main'", Some("main")),
+            ("Already on 'develop'", Some("develop")),
+            ("Switched to a new branch 'codex/reserve-deprecated-signals'", Some("codex/reserve-deprecated-signals")),
+            // No match
+            ("some random output", None),
+            ("branch 'foo' deleted", None),
+        ];
+        for (output, expected) in cases {
+            let payload = serde_json::json!({
+                "type": "function_call_output",
+                "output": output,
+            });
+            assert_eq!(
+                extract_branch_from_output(&payload).as_deref(),
+                expected,
+                "failed for output: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_branch_wrong_type() {
+        let payload = serde_json::json!({
+            "type": "agent_reasoning",
+            "output": "Switched to a new branch 'foo'",
+        });
+        assert_eq!(extract_branch_from_output(&payload), None);
+    }
+
+    // -- parse_session_file tests --
+
+    fn session_meta_line(cwd: &str, branch: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "cwd": cwd,
+                "git": { "branch": branch }
+            }
+        })).unwrap()
+    }
+
+    fn user_msg_line(text: &str, ts: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "type": "response_item",
+            "timestamp": ts,
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": text }]
+            }
+        })).unwrap()
+    }
+
+    fn checkout_line(output: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "type": "event_msg",
+            "timestamp": "2025-01-15T10:05:00Z",
+            "payload": {
+                "type": "function_call_output",
+                "output": output,
+            }
+        })).unwrap()
+    }
+
+    #[test]
+    fn test_codex_parse_initial_branch() {
+        let content = format!(
+            "{}\n{}\n",
+            session_meta_line("/Users/me/src/server", "main"),
+            user_msg_line("hello world from the user", "2025-01-15T10:00:00Z"),
+        );
+        let f = write_tempfile(&content);
+        let (meta, chunks) = parse_session_file(f.path());
+        assert_eq!(meta.branch.as_deref(), Some("main"));
+        assert_eq!(meta.cwd.as_deref(), Some("/Users/me/src/server"));
+        assert_eq!(chunks.len(), 1);
+    }
+
+    #[test]
+    fn test_codex_parse_branch_switch_overrides() {
+        let content = format!(
+            "{}\n{}\n{}\n",
+            session_meta_line("/Users/me/src/server", "main"),
+            checkout_line("Switched to a new branch 'feature/xyz'"),
+            user_msg_line("do some work on the branch", "2025-01-15T10:10:00Z"),
+        );
+        let f = write_tempfile(&content);
+        let (meta, _) = parse_session_file(f.path());
+        assert_eq!(meta.branch.as_deref(), Some("feature/xyz"));
+    }
+
+    #[test]
+    fn test_codex_parse_multiple_switches_last_wins() {
+        let content = format!(
+            "{}\n{}\n{}\n{}\n",
+            session_meta_line("/Users/me/src/server", "main"),
+            checkout_line("Switched to a new branch 'first-branch'"),
+            checkout_line("Switched to branch 'second-branch'"),
+            user_msg_line("work on second branch now", "2025-01-15T10:10:00Z"),
+        );
+        let f = write_tempfile(&content);
+        let (meta, _) = parse_session_file(f.path());
+        assert_eq!(meta.branch.as_deref(), Some("second-branch"));
+    }
+
+    #[test]
+    fn test_codex_parse_session_meta_after_checkout_doesnt_overwrite() {
+        // session_meta branch is first-write-only, so a later session_meta
+        // should NOT overwrite a branch detected from exec output
+        let content = format!(
+            "{}\n{}\n{}\n{}\n",
+            session_meta_line("/Users/me/src/server", "main"),
+            checkout_line("Switched to a new branch 'feature/new'"),
+            // second session_meta (e.g. from a reconnect)
+            session_meta_line("/Users/me/src/server", "main"),
+            user_msg_line("still on feature branch", "2025-01-15T10:10:00Z"),
+        );
+        let f = write_tempfile(&content);
+        let (meta, _) = parse_session_file(f.path());
+        assert_eq!(meta.branch.as_deref(), Some("feature/new"));
+    }
+
+    #[test]
+    fn test_codex_parse_empty_file() {
+        let f = write_tempfile("");
+        let (meta, chunks) = parse_session_file(f.path());
+        assert!(meta.branch.is_none());
+        assert!(meta.cwd.is_none());
+        assert!(chunks.is_empty());
+    }
+
+    // -- session_id_from_filename --
+
+    #[test]
+    fn test_session_id_from_filename() {
+        let cases = vec![
+            ("rollout-2025-01-15T10-00-00-abcdef01-2345-6789-abcd-ef0123456789.jsonl",
+             "abcdef01-2345-6789-abcd-ef0123456789"),
+            ("short.jsonl", "short"),
+        ];
+        for (filename, expected) in cases {
+            let path = PathBuf::from(filename);
+            assert_eq!(session_id_from_filename(&path), expected, "failed for {filename}");
+        }
+    }
+
+    // -- project_from_cwd --
+
+    #[test]
+    fn test_project_from_cwd() {
+        assert_eq!(project_from_cwd("/Users/me/src/server"), "server");
+        assert_eq!(project_from_cwd("/Users/me/src/dash-search-debugger"), "dash-search-debugger");
+        // Root path has no file_name, falls back to the input string
+        assert_eq!(project_from_cwd("/"), "/");
+    }
 }

--- a/examples/pickbrain/main.rs
+++ b/examples/pickbrain/main.rs
@@ -63,6 +63,7 @@ fn embed_and_index(db: &DB, embedder: &Embedder, device: &candle_core::Device) -
 
 // --- Search result data ---
 
+#[derive(Clone)]
 struct TurnMeta {
     role: String,
     timestamp: String,
@@ -70,14 +71,17 @@ struct TurnMeta {
     byte_len: u64,
 }
 
+#[derive(Clone)]
 struct SearchResult {
     timestamp: String,
     project: String,
     session_id: String,
+    session_name: String,
     turn: u64,
     path: String,
     cwd: String,
     source: String,
+    branch: String,
     bodies: Vec<String>,
     match_idx: usize,
     turns: Vec<TurnMeta>,
@@ -159,57 +163,51 @@ fn parse_since(s: &str) -> Option<i64> {
     Some(n * ms_per_unit)
 }
 
-fn run_search(
-    db_name: &PathBuf,
-    assets: &PathBuf,
-    q: &str,
+fn build_sql_filter(
     session: Option<&str>,
+    branch: Option<&str>,
     exclude: &[String],
     since_ms: Option<i64>,
-) -> Result<(Vec<SearchResult>, u128)> {
+) -> Option<witchcraft::types::SqlStatementInternal> {
     use witchcraft::types::*;
-    let device = witchcraft::make_device();
-    let embedder = witchcraft::Embedder::new(&device, assets)?;
-
-    let mut cache = witchcraft::EmbeddingsCache::new(1);
-    let db = DB::new_reader(db_name.clone()).unwrap();
-
-    let session_filter = session.map(|id| SqlStatementInternal {
-        statement_type: SqlStatementType::Condition,
-        condition: Some(SqlConditionInternal {
-            key: "$.session_id".to_string(),
-            operator: SqlOperator::Equals,
-            value: Some(SqlValue::String(id.to_string())),
-        }),
-        logic: None,
-        statements: None,
-    });
-
-    let exclude_filter = if exclude.is_empty() {
-        None
-    } else {
-        let stmts: Vec<SqlStatementInternal> = exclude
-            .iter()
-            .map(|id| SqlStatementInternal {
-                statement_type: SqlStatementType::Condition,
-                condition: Some(SqlConditionInternal {
-                    key: "$.session_id".to_string(),
-                    operator: SqlOperator::NotEquals,
-                    value: Some(SqlValue::String(id.clone())),
-                }),
-                logic: None,
-                statements: None,
-            })
-            .collect();
-        Some(SqlStatementInternal {
-            statement_type: SqlStatementType::Group,
-            condition: None,
-            logic: Some(SqlLogic::And),
-            statements: Some(stmts),
-        })
-    };
-
-    let since_filter = since_ms.map(|ms| {
+    let mut conditions: Vec<SqlStatementInternal> = Vec::new();
+    if let Some(id) = session {
+        conditions.push(SqlStatementInternal {
+            statement_type: SqlStatementType::Condition,
+            condition: Some(SqlConditionInternal {
+                key: "$.session_id".to_string(),
+                operator: SqlOperator::Equals,
+                value: Some(SqlValue::String(id.to_string())),
+            }),
+            logic: None,
+            statements: None,
+        });
+    }
+    if let Some(br) = branch {
+        conditions.push(SqlStatementInternal {
+            statement_type: SqlStatementType::Condition,
+            condition: Some(SqlConditionInternal {
+                key: "$.branch".to_string(),
+                operator: SqlOperator::Equals,
+                value: Some(SqlValue::String(br.to_string())),
+            }),
+            logic: None,
+            statements: None,
+        });
+    }
+    for id in exclude {
+        conditions.push(SqlStatementInternal {
+            statement_type: SqlStatementType::Condition,
+            condition: Some(SqlConditionInternal {
+                key: "$.session_id".to_string(),
+                operator: SqlOperator::NotEquals,
+                value: Some(SqlValue::String(id.clone())),
+            }),
+            logic: None,
+            statements: None,
+        });
+    }
+    if let Some(ms) = since_ms {
         let cutoff_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -217,7 +215,7 @@ fn run_search(
             - ms / 1000;
         let cutoff_dt = chrono::DateTime::from_timestamp(cutoff_secs, 0).unwrap();
         let cutoff_iso = cutoff_dt.to_rfc3339();
-        SqlStatementInternal {
+        conditions.push(SqlStatementInternal {
             statement_type: SqlStatementType::Condition,
             condition: Some(SqlConditionInternal {
                 key: "date".to_string(),
@@ -226,38 +224,26 @@ fn run_search(
             }),
             logic: None,
             statements: None,
-        }
-    });
-
-    let filters: Vec<SqlStatementInternal> = [session_filter, exclude_filter, since_filter]
-        .into_iter()
-        .flatten()
-        .collect();
-
-    let sql_filter = match filters.len() {
-        0 => None,
-        1 => Some(filters.into_iter().next().unwrap()),
-        _ => Some(SqlStatementInternal {
+        });
+    }
+    if conditions.is_empty() {
+        None
+    } else if conditions.len() == 1 {
+        Some(conditions.remove(0))
+    } else {
+        Some(SqlStatementInternal {
             statement_type: SqlStatementType::Group,
             condition: None,
             logic: Some(SqlLogic::And),
-            statements: Some(filters),
-        }),
-    };
-    let now = std::time::Instant::now();
-    let results = witchcraft::search(
-        &db,
-        &embedder,
-        &mut cache,
-        q,
-        0.5,
-        10,
-        true,
-        sql_filter.as_ref(),
-    )?;
-    let search_ms = now.elapsed().as_millis();
+            statements: Some(conditions),
+        })
+    }
+}
 
-    let out: Vec<SearchResult> = results
+fn parse_search_results(
+    results: Vec<(f32, String, Vec<String>, u32, String)>,
+) -> Vec<SearchResult> {
+    results
         .into_iter()
         .map(|(_score, metadata, bodies, sub_idx, date)| {
             let meta: serde_json::Value = serde_json::from_str(&metadata).unwrap_or_default();
@@ -279,17 +265,58 @@ fn run_search(
                 timestamp: format_date(&date),
                 project: meta["project"].as_str().unwrap_or("").to_string(),
                 session_id: meta["session_id"].as_str().unwrap_or("").to_string(),
+                session_name: meta["session_name"].as_str().unwrap_or("").to_string(),
                 turn: meta["turn"].as_u64().unwrap_or(0),
                 path: meta["path"].as_str().unwrap_or("").to_string(),
                 cwd: meta["cwd"].as_str().unwrap_or("").to_string(),
                 source: meta["source"].as_str().unwrap_or("claude").to_string(),
+                branch: meta["branch"].as_str().unwrap_or("").to_string(),
                 bodies,
                 match_idx: idx,
                 turns: turns_arr,
             }
         })
-        .collect();
-    Ok((out, search_ms))
+        .collect()
+}
+
+fn run_search(
+    db_name: &PathBuf,
+    assets: &PathBuf,
+    q: &str,
+    session: Option<&str>,
+    branch: Option<&str>,
+    exclude: &[String],
+    since_ms: Option<i64>,
+) -> Result<(Vec<SearchResult>, u128)> {
+    let device = witchcraft::make_device();
+    let embedder = witchcraft::Embedder::new(&device, assets)?;
+    run_search_with(&DB::new_reader(db_name.clone()).unwrap(), &embedder, q, session, branch, exclude, since_ms)
+}
+
+fn run_search_with(
+    db: &DB,
+    embedder: &Embedder,
+    q: &str,
+    session: Option<&str>,
+    branch: Option<&str>,
+    exclude: &[String],
+    since_ms: Option<i64>,
+) -> Result<(Vec<SearchResult>, u128)> {
+    let mut cache = witchcraft::EmbeddingsCache::new(1);
+    let sql_filter = build_sql_filter(session, branch, exclude, since_ms);
+    let now = std::time::Instant::now();
+    let results = witchcraft::search(
+        db,
+        embedder,
+        &mut cache,
+        q,
+        0.5,
+        10,
+        true,
+        sql_filter.as_ref(),
+    )?;
+    let search_ms = now.elapsed().as_millis();
+    Ok((parse_search_results(results), search_ms))
 }
 
 // --- TUI ---
@@ -304,14 +331,19 @@ fn search_tui(
     assets: &PathBuf,
     q: &str,
     session: Option<&str>,
+    branch: Option<&str>,
     exclude: &[String],
     since_ms: Option<i64>,
-) -> Result<Option<(String, String, String)>> {
-    let (results, search_ms) = run_search(db_name, assets, q, session, exclude, since_ms)?;
+) -> Result<Option<(String, String, String, String, String)>> {
+    let device = witchcraft::make_device();
+    let embedder = witchcraft::Embedder::new(&device, assets)?;
+    let db = DB::new_reader(db_name.clone()).unwrap();
+    let (mut results, mut search_ms) = run_search_with(&db, &embedder, q, session, branch, exclude, since_ms)?;
     if results.is_empty() {
         eprintln!("no results");
         return Ok(None);
     }
+    let mut active_query = q.to_string();
 
     use crossterm::event::{self, Event, KeyCode, KeyModifiers};
     use crossterm::terminal::{
@@ -335,8 +367,11 @@ fn search_tui(
     let mut list_state = ListState::default();
     list_state.select(Some(0));
     let mut scroll_offset: usize = 0;
-    let mut resume_session: Option<(String, String, String)> = None;
-    let mut confirm_resume: Option<(String, String, String, String)> = None;
+    let mut resume_session: Option<(String, String, String, String, String)> = None;
+    let mut confirm_resume: Option<(String, String, String, String, String)> = None;
+    let mut searching = false;
+    let mut search_filter = String::new();
+    let mut saved_search: Option<(String, Vec<SearchResult>, u128)> = None;
     struct DetailState {
         result_idx: usize,
         turns: Vec<SessionTurn>,
@@ -345,53 +380,81 @@ fn search_tui(
     let mut detail_cache: Option<DetailState> = None;
 
     loop {
+        if selected >= results.len() {
+            selected = results.len().saturating_sub(1);
+        }
+        list_state.select(if results.is_empty() { None } else { Some(selected) });
+
         terminal.draw(|f| {
             let area = f.area();
             let show_footer = confirm_resume.is_some() && matches!(view, View::Detail(_));
+            let show_search = searching || !search_filter.is_empty();
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints(if show_footer {
-                    vec![Constraint::Length(2), Constraint::Min(0), Constraint::Length(1)]
+                    vec![Constraint::Length(2), Constraint::Length(if show_search { 1 } else { 0 }), Constraint::Min(0), Constraint::Length(1)]
                 } else {
-                    vec![Constraint::Length(2), Constraint::Min(0), Constraint::Length(0)]
+                    vec![Constraint::Length(2), Constraint::Length(if show_search { 1 } else { 0 }), Constraint::Min(0), Constraint::Length(0)]
                 })
                 .split(area);
 
             // Header
+            let help_text = if searching {
+                "type query  ⏎ search  esc cancel"
+            } else {
+                match view {
+                    View::List => "↑↓/jk navigate  ⏎ open  / search  q quit",
+                    View::Detail(idx) if !results[idx].session_id.is_empty() => {
+                        "↑↓/jk scroll  r resume  / search  esc back  q quit"
+                    }
+                    View::Detail(_) => "↑↓/jk scroll  / search  esc back  q quit",
+                }
+            };
             let header = Paragraph::new(Line::from(vec![
                 Span::styled(
-                    format!("[[ {q} ]]"),
+                    format!("[[ {} ]]", active_query),
                     Style::default()
                         .fg(Color::Rgb(0, 255, 0))
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    format!("  {search_ms} ms  "),
+                    format!("  {} results  {} ms  ", results.len(), search_ms),
                     Style::default().fg(Color::DarkGray),
                 ),
-                Span::styled(
-                    match view {
-                        View::List => "↑↓ navigate  ⏎ open  q quit",
-                        View::Detail(idx) if !results[idx].session_id.is_empty() => {
-                            "↑↓ scroll  r resume session  esc back  q quit"
-                        }
-                        View::Detail(_) => "↑↓ scroll  esc back  q quit",
-                    },
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled(help_text, Style::default().fg(Color::DarkGray)),
             ]));
             f.render_widget(header, chunks[0]);
+
+            // Search input bar
+            if show_search {
+                let search_bar = Paragraph::new(Line::from(vec![
+                    Span::styled("/ ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        &search_filter,
+                        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    ),
+                    if searching {
+                        Span::styled("_", Style::default().fg(Color::DarkGray))
+                    } else {
+                        Span::raw("")
+                    },
+                ]));
+                f.render_widget(search_bar, chunks[1]);
+            }
+
+            let content_area = chunks[2];
+            let footer_area = chunks[3];
 
             // Footer: resume confirmation
             if show_footer {
                 let cwd = confirm_resume.as_ref()
-                    .map(|(_, _, c, _)| c.as_str())
+                    .map(|(_, _, c, _, _)| c.as_str())
                     .unwrap_or("?");
                 let sid = confirm_resume.as_ref()
-                    .map(|(s, _, _, _)| s.as_str())
+                    .map(|(s, _, _, _, _)| s.as_str())
                     .unwrap_or("?");
                 let src = confirm_resume.as_ref()
-                    .map(|(_, _, _, s)| s.as_str())
+                    .map(|(_, _, _, s, _)| s.as_str())
                     .unwrap_or("claude");
                 let footer = Paragraph::new(Line::from(vec![
                     Span::styled(
@@ -405,12 +468,12 @@ fn search_tui(
                         Style::default().add_modifier(Modifier::BOLD),
                     ),
                 ]));
-                f.render_widget(footer, chunks[2]);
+                f.render_widget(footer, footer_area);
             }
 
             match view {
                 View::List => {
-                    let width = chunks[1].width as usize;
+                    let width = content_area.width as usize;
                     let items: Vec<ratatui::widgets::ListItem> = results
                         .iter()
                         .map(|r| {
@@ -430,13 +493,9 @@ fn search_tui(
                                 .filter(|tm| !tm.timestamp.is_empty())
                                 .map(|tm| format_date(&tm.timestamp))
                                 .unwrap_or_else(|| r.timestamp.clone());
-                            let mut meta_spans = vec![
-                                Span::styled(
-                                    format!("{ts} "),
-                                    Style::default().fg(Color::Green),
-                                ),
-                                Span::styled(&r.project, Style::default().fg(Color::Cyan)),
-                            ];
+                            let mut meta_spans = session_meta_spans(
+                                &ts, &r.project, &r.session_id, &r.session_name, &r.source, &r.branch,
+                            );
                             if r.path.ends_with(".md") {
                                 meta_spans.push(Span::styled(
                                     format!("  {}", r.path),
@@ -444,20 +503,6 @@ fn search_tui(
                                 ));
                             }
                             if !r.session_id.is_empty() {
-                                let source_label = if r.source == "codex" {
-                                    "codex"
-                                } else {
-                                    "claude"
-                                };
-                                let short_sid = if r.session_id.len() > 8 {
-                                    &r.session_id[..8]
-                                } else {
-                                    &r.session_id
-                                };
-                                meta_spans.push(Span::styled(
-                                    format!("  {source_label} {short_sid}"),
-                                    Style::default().fg(Color::Magenta),
-                                ));
                                 meta_spans.push(Span::styled(
                                     format!("  turn {}", r.turn),
                                     Style::default().fg(Color::DarkGray),
@@ -494,7 +539,7 @@ fn search_tui(
                             .bg(Color::DarkGray)
                             .add_modifier(Modifier::BOLD),
                     );
-                    f.render_stateful_widget(list, chunks[1], &mut list_state);
+                    f.render_stateful_widget(list, content_area, &mut list_state);
                 }
                 View::Detail(idx) => {
                     let r = &results[idx];
@@ -509,13 +554,26 @@ fn search_tui(
                         Span::styled(&r.project, Style::default().fg(Color::Cyan)),
                     ]));
                     if !r.session_id.is_empty() {
-                        lines.push(Line::from(vec![
+                        let mut session_spans = vec![
                             Span::styled(&r.session_id, Style::default().fg(Color::Magenta)),
-                            Span::styled(
-                                format!("  turn {}", r.turn),
-                                Style::default().fg(Color::DarkGray),
-                            ),
-                        ]));
+                        ];
+                        if !r.session_name.is_empty() {
+                            session_spans.push(Span::styled(
+                                format!("  \"{}\"", r.session_name),
+                                Style::default().fg(Color::White),
+                            ));
+                        }
+                        session_spans.push(Span::styled(
+                            format!("  turn {}", r.turn),
+                            Style::default().fg(Color::DarkGray),
+                        ));
+                        if !r.branch.is_empty() {
+                            session_spans.push(Span::styled(
+                                format!("  {}", r.branch),
+                                Style::default().fg(Color::Yellow),
+                            ));
+                        }
+                        lines.push(Line::from(session_spans));
                     }
                     lines.push(Line::from(""));
 
@@ -580,12 +638,64 @@ fn search_tui(
                     let detail = Paragraph::new(lines)
                         .wrap(Wrap { trim: false })
                         .scroll((scroll_offset as u16, 0));
-                    f.render_widget(detail, chunks[1]);
+                    f.render_widget(detail, content_area);
                 }
             }
         })?;
 
         if let Event::Key(key) = event::read()? {
+            // Search mode: live-search as the user types
+            if searching {
+                match (key.code, key.modifiers) {
+                    (KeyCode::Esc, _) => {
+                        searching = false;
+                        search_filter.clear();
+                        // Restore pre-search state
+                        if let Some((q, r, ms)) = saved_search.take() {
+                            active_query = q;
+                            results = r;
+                            search_ms = ms;
+                            selected = 0;
+                            detail_cache = None;
+                            view = View::List;
+                        }
+                        continue;
+                    }
+                    (KeyCode::Enter, _) => {
+                        searching = false;
+                        saved_search = None;
+                        continue;
+                    }
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                    (KeyCode::Backspace, _) => { search_filter.pop(); }
+                    (KeyCode::Char(c), _) => { search_filter.push(c); }
+                    _ => {}
+                }
+                // Live search: update results as the user types (>= 3 chars)
+                if search_filter.chars().count() >= 3 {
+                    if let Ok((new_results, ms)) = run_search_with(
+                        &db, &embedder, &search_filter, session, branch, exclude, since_ms,
+                    ) {
+                        active_query = search_filter.clone();
+                        results = new_results;
+                        search_ms = ms;
+                        selected = 0;
+                        detail_cache = None;
+                        view = View::List;
+                    }
+                } else if search_filter.is_empty() {
+                    if let Some((ref q, ref r, ms)) = saved_search {
+                        active_query = q.clone();
+                        results = r.clone();
+                        search_ms = ms;
+                        selected = 0;
+                        detail_cache = None;
+                        view = View::List;
+                    }
+                }
+                continue;
+            }
+
             match (&view, key.code, key.modifiers) {
                 (_, KeyCode::Char('q') | KeyCode::Esc, _) if confirm_resume.is_some() => {
                     confirm_resume = None;
@@ -593,8 +703,15 @@ fn search_tui(
                 (View::Detail(_), KeyCode::Char('q') | KeyCode::Esc, _) => {
                     view = View::List;
                 }
-                (View::List, KeyCode::Char('q') | KeyCode::Esc, _) => break,
+                (View::List, KeyCode::Char('q'), _) => break,
+                (View::List, KeyCode::Esc, _) => break,
                 (_, KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                (_, KeyCode::Char('f'), KeyModifiers::CONTROL) |
+                (_, KeyCode::Char('/'), _) => {
+                    searching = true;
+                    search_filter.clear();
+                    saved_search = Some((active_query.clone(), results.clone(), search_ms));
+                }
                 (_, KeyCode::Char('z'), KeyModifiers::CONTROL) => {
                     disable_raw_mode()?;
                     crossterm::execute!(
@@ -603,14 +720,12 @@ fn search_tui(
                         crossterm::cursor::Show
                     )?;
                     unsafe { libc::raise(libc::SIGTSTP); }
-                    // When resumed (fg), re-enter TUI
                     enable_raw_mode()?;
                     crossterm::execute!(
                         std::io::stdout(),
                         EnterAlternateScreen,
                         crossterm::cursor::Hide
                     )?;
-                    // Force full redraw
                     terminal.clear()?;
                 }
 
@@ -628,34 +743,35 @@ fn search_tui(
                     }
                 }
                 (View::List, KeyCode::Enter, _) => {
-                    let r = &results[selected];
-                    if !r.session_id.is_empty() && !r.path.is_empty() && !r.turns.is_empty() {
-                        let mi = if r.match_idx > 0 { r.match_idx - 1 } else { 0 };
-                        let mut turns = Vec::new();
-                        for tm in &r.turns {
-                            if let Some(turn) = read_turn_at(&r.path, &r.source, tm) {
-                                turns.push(turn);
+                    if selected < results.len() {
+                        let r = &results[selected];
+                        if !r.session_id.is_empty() && !r.path.is_empty() && !r.turns.is_empty() {
+                            let mi = if r.match_idx > 0 { r.match_idx - 1 } else { 0 };
+                            let mut turns = Vec::new();
+                            for tm in &r.turns {
+                                if let Some(turn) = read_turn_at(&r.path, &r.source, tm) {
+                                    turns.push(turn);
+                                }
                             }
+                            let mut pre_lines: usize = if r.session_id.is_empty() { 2 } else { 3 };
+                            for t in &turns[..mi.min(turns.len())] {
+                                pre_lines += 2 + t.text.lines().count();
+                            }
+                            scroll_offset = pre_lines;
+                            detail_cache = Some(DetailState {
+                                result_idx: selected,
+                                turns,
+                                highlight: mi,
+                            });
+                        } else {
+                            scroll_offset = 0;
+                            detail_cache = None;
                         }
-                        // Position viewport at the highlight turn
-                        let mut pre_lines: usize = if r.session_id.is_empty() { 2 } else { 3 };
-                        for t in &turns[..mi.min(turns.len())] {
-                            pre_lines += 2 + t.text.lines().count();
-                        }
-                        scroll_offset = pre_lines;
-                        detail_cache = Some(DetailState {
-                            result_idx: selected,
-                            turns,
-                            highlight: mi,
-                        });
-                    } else {
-                        scroll_offset = 0;
-                        detail_cache = None;
+                        view = View::Detail(selected);
                     }
-                    view = View::Detail(selected);
                 }
 
-                // Detail view: j/k line scroll
+                // Detail view
                 (View::Detail(_), KeyCode::Down | KeyCode::Char('j'), _) => {
                     scroll_offset = scroll_offset.saturating_add(1);
                 }
@@ -671,12 +787,12 @@ fn search_tui(
                             read_cwd_from_jsonl(&r.path, &r.source)
                                 .unwrap_or_else(|| "?".to_string())
                         };
-                        confirm_resume = Some((r.session_id.clone(), r.path.clone(), cwd, r.source.clone()));
+                        confirm_resume = Some((r.session_id.clone(), r.path.clone(), cwd, r.source.clone(), r.branch.clone()));
                     }
                 }
                 (View::Detail(_), KeyCode::Char('y') | KeyCode::Enter, _) => {
-                    if let Some((ref sid, ref path, _, ref source)) = confirm_resume {
-                        resume_session = Some((sid.clone(), path.clone(), source.clone()));
+                    if let Some((ref sid, ref _path, ref cwd, ref source, ref branch)) = confirm_resume {
+                        resume_session = Some((sid.clone(), source.clone(), branch.clone(), cwd.clone(), _path.clone()));
                         break;
                     }
                 }
@@ -714,10 +830,41 @@ fn read_cwd_from_jsonl(path: &str, source: &str) -> Option<String> {
     None
 }
 
-fn launch_resume(session_id: &str, jsonl_path: &str, source: &str) -> Result<()> {
+/// Returns true only if `git status --porcelain` succeeds with empty output
+/// (i.e. no staged, unstaged, or untracked changes). Returns false if not
+/// in a git repo or if the tree is dirty.
+fn git_working_tree_clean() -> bool {
+    std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|o| o.status.success() && o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn launch_resume(session_id: &str, source: &str, branch: &str, cwd: &str) -> Result<()> {
     use std::os::unix::process::CommandExt;
-    if let Some(cwd) = read_cwd_from_jsonl(jsonl_path, source) {
-        let _ = std::env::set_current_dir(&cwd);
+    if !cwd.is_empty() {
+        let _ = std::env::set_current_dir(cwd);
+    }
+    if !branch.is_empty() {
+        let current = current_git_branch().unwrap_or_default();
+        if current != branch {
+            if !git_working_tree_clean() {
+                eprintln!(
+                    "warning: working tree is dirty, staying on '{current}' \
+                     (stash or commit before switching to '{branch}')"
+                );
+            } else {
+                let status = std::process::Command::new("git")
+                    .args(["checkout", branch])
+                    .status();
+                match status {
+                    Ok(s) if s.success() => {}
+                    Ok(_) => eprintln!("warning: git checkout '{branch}' failed, continuing on '{current}'"),
+                    Err(e) => eprintln!("warning: git checkout failed: {e}"),
+                }
+            }
+        }
     }
     if source == "codex" {
         eprintln!("Resuming codex session {session_id}...");
@@ -764,10 +911,11 @@ fn search_plain(
     assets: &PathBuf,
     q: &str,
     session: Option<&str>,
+    branch: Option<&str>,
     exclude: &[String],
     since_ms: Option<i64>,
 ) -> Result<()> {
-    let (results, search_ms) = run_search(db_name, assets, q, session, exclude, since_ms)?;
+    let (results, search_ms) = run_search(db_name, assets, q, session, branch, exclude, since_ms)?;
 
     let mut buf = Vec::new();
     writeln!(buf, "\n[[ {q} ]]")?;
@@ -790,12 +938,22 @@ fn search_plain(
         } else {
             String::new()
         };
-        let session_info = if !r.session_id.is_empty() {
-            format!("  {source_label} {} turn {}", r.session_id, r.turn)
+        let name_info = if !r.session_name.is_empty() {
+            format!(" \"{}\"", r.session_name)
         } else {
             String::new()
         };
-        writeln!(buf, "{ts}  {}{filename}{session_info}", r.project)?;
+        let session_info = if !r.session_id.is_empty() {
+            format!("  {source_label} {}{name_info} turn {}", r.session_id, r.turn)
+        } else {
+            String::new()
+        };
+        let branch_info = if !r.branch.is_empty() {
+            format!("  [{}]", r.branch)
+        } else {
+            String::new()
+        };
+        writeln!(buf, "{ts}  {}{filename}{session_info}{branch_info}", r.project)?;
         if !r.session_id.is_empty() && !r.path.is_empty() && !r.turns.is_empty() {
             // Read only the matched turn + neighbors via byte offsets
             let mi = if r.match_idx > 0 { r.match_idx - 1 } else { 0 };
@@ -831,6 +989,448 @@ fn search_plain(
     }
     std::io::stdout().write_all(&buf)?;
     Ok(())
+}
+
+/// Build styled spans for session metadata display. Returns `Span<'static>`
+/// because all values are owned (format!/to_string), not borrowed from args.
+fn session_meta_spans(
+    date: &str,
+    project: &str,
+    session_id: &str,
+    session_name: &str,
+    source: &str,
+    branch: &str,
+) -> Vec<ratatui::text::Span<'static>> {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::Span;
+
+    let mut spans = vec![
+        Span::styled(format!("{} ", format_date(date)), Style::default().fg(Color::Green)),
+        Span::styled(project.to_string(), Style::default().fg(Color::Cyan)),
+    ];
+    if !session_id.is_empty() {
+        let source_label = if source == "codex" { "codex" } else { "claude" };
+        let short_sid = if session_id.len() > 8 { &session_id[..8] } else { session_id };
+        spans.push(Span::styled(
+            format!("  {source_label} {short_sid}"),
+            Style::default().fg(Color::Magenta),
+        ));
+    }
+    if !session_name.is_empty() {
+        spans.push(Span::styled(
+            format!("  \"{session_name}\""),
+            Style::default().fg(Color::White),
+        ));
+    }
+    if !branch.is_empty() {
+        spans.push(Span::styled(
+            format!("  {branch}"),
+            Style::default().fg(Color::Yellow),
+        ));
+    }
+    spans
+}
+
+fn current_git_branch() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if branch.is_empty() || branch == "HEAD" {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+#[derive(Clone)]
+struct BranchSession {
+    session_id: String,
+    session_name: String,
+    source: String,
+    path: String,
+    project: String,
+    branch: String,
+    cwd: String,
+    date: String,
+    title: String,
+}
+
+/// Convert search results into BranchSessions for the resume picker,
+/// deduplicating by session_id (keeping the first/best match per session).
+fn results_to_sessions(results: &[SearchResult]) -> Vec<BranchSession> {
+    let mut seen = std::collections::HashSet::new();
+    results
+        .iter()
+        .filter(|r| !r.session_id.is_empty())
+        .filter(|r| seen.insert(r.session_id.clone()))
+        .map(|r| {
+            let title = r.bodies.get(r.match_idx)
+                .map(|b| first_line(b))
+                .map(|l| strip_body_prefix(&l).to_string())
+                .unwrap_or_default()
+                .chars()
+                .take(80)
+                .collect::<String>();
+            BranchSession {
+                session_id: r.session_id.clone(),
+                session_name: r.session_name.clone(),
+                source: r.source.clone(),
+                path: r.path.clone(),
+                project: r.project.clone(),
+                branch: r.branch.clone(),
+                cwd: r.cwd.clone(),
+                date: r.timestamp.clone(),
+                title,
+            }
+        })
+        .collect()
+}
+
+fn find_sessions_for_branch(db_name: &PathBuf, branch: &str) -> Result<Vec<BranchSession>> {
+    let db = DB::new_reader(db_name.clone()).unwrap();
+    let mut stmt = db.query(
+        "SELECT metadata, body, date FROM document
+         WHERE json_extract(metadata, '$.branch') = ?1
+         ORDER BY date DESC",
+    )?;
+    let rows: Vec<(String, String, String)> = stmt
+        .query_map((branch,), |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Deduplicate by session_id, keeping the most recent turn per session
+    let mut seen = std::collections::HashSet::new();
+    let mut sessions = Vec::new();
+    for (metadata, body, date) in &rows {
+        let meta: serde_json::Value = serde_json::from_str(metadata).unwrap_or_default();
+        let sid = meta["session_id"].as_str().unwrap_or("").to_string();
+        if sid.is_empty() || !seen.insert(sid.clone()) {
+            continue;
+        }
+        // Extract title from the first [User] line in the body
+        let title = body
+            .lines()
+            .find(|l| l.starts_with("[User]"))
+            .map(|l| l.strip_prefix("[User] ").unwrap_or(l))
+            .unwrap_or("")
+            .chars()
+            .take(80)
+            .collect::<String>();
+        sessions.push(BranchSession {
+            session_id: sid,
+            session_name: meta["session_name"].as_str().unwrap_or("").to_string(),
+            source: meta["source"].as_str().unwrap_or("claude").to_string(),
+            path: meta["path"].as_str().unwrap_or("").to_string(),
+            project: meta["project"].as_str().unwrap_or("").to_string(),
+            branch: meta["branch"].as_str().unwrap_or("").to_string(),
+            cwd: meta["cwd"].as_str().unwrap_or("").to_string(),
+            date: date.clone(),
+            title,
+        });
+    }
+    Ok(sessions)
+}
+
+fn pick_and_resume(
+    sessions: Vec<BranchSession>,
+    context: &str,
+    db_name: &PathBuf,
+    assets: &PathBuf,
+    branch_filter: Option<&str>,
+) -> Result<()> {
+    if sessions.is_empty() {
+        eprintln!("No sessions found {context}");
+        std::process::exit(1);
+    }
+    if sessions.len() == 1 {
+        let s = &sessions[0];
+        if !std::path::Path::new(&s.path).exists() {
+            anyhow::bail!("session file no longer exists: {}", s.path);
+        }
+        launch_resume(&s.session_id, &s.source, &s.branch, &s.cwd)?;
+        return Ok(());
+    }
+
+    // Lazy-load embedder+db only when user first presses `/` to search
+    let mut search_engine: Option<(Embedder, DB)> = None;
+
+    use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+    use crossterm::terminal::{
+        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    };
+    use ratatui::backend::CrosstermBackend;
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::ListState;
+    use ratatui::Terminal;
+
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    crossterm::execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut active_sessions = sessions.clone();
+    let mut query = String::new();
+    let mut searching = false;
+    let mut selected: usize = 0;
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+    let mut chosen: Option<usize> = None;
+
+    loop {
+        // Clamp selection
+        if selected >= active_sessions.len() {
+            selected = active_sessions.len().saturating_sub(1);
+        }
+        list_state.select(if active_sessions.is_empty() { None } else { Some(selected) });
+
+        terminal.draw(|f| {
+            let area = f.area();
+            let show_search = searching || !query.is_empty();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),  // header
+                    Constraint::Length(if show_search { 1 } else { 0 }),  // search bar
+                    Constraint::Min(0),     // list
+                ])
+                .split(area);
+
+            // Header
+            let count_label = if query.is_empty() {
+                format!("{} sessions", active_sessions.len())
+            } else {
+                format!("{} results", active_sessions.len())
+            };
+            let help_text = if searching {
+                "type query  ⏎ search  esc cancel"
+            } else {
+                "↑↓/jk navigate  ⏎ resume  / filter  q quit"
+            };
+            let header = Line::from(vec![
+                Span::styled(
+                    format!("[[ resume {context} ]]  "),
+                    Style::default()
+                        .fg(Color::Rgb(0, 255, 0))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{count_label}  "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(help_text, Style::default().fg(Color::DarkGray)),
+            ]);
+            f.render_widget(ratatui::widgets::Paragraph::new(header), chunks[0]);
+
+            // Search bar
+            if show_search {
+                let search_line = Line::from(vec![
+                    Span::styled("/ ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        &query,
+                        Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                    ),
+                    if searching {
+                        Span::styled("_", Style::default().fg(Color::DarkGray))
+                    } else {
+                        Span::raw("")
+                    },
+                ]);
+                f.render_widget(ratatui::widgets::Paragraph::new(search_line), chunks[1]);
+            }
+
+            let width = chunks[2].width as usize;
+            let items: Vec<ratatui::widgets::ListItem> = active_sessions
+                .iter()
+                .map(|s| {
+                    let meta_spans = session_meta_spans(
+                        &s.date, &s.project, &s.session_id, &s.session_name, &s.source, &s.branch,
+                    );
+                    ratatui::widgets::ListItem::new(vec![
+                        Line::from(meta_spans),
+                        Line::from(vec![
+                            Span::raw("  "),
+                            Span::raw(truncate(&s.title, width.saturating_sub(4))),
+                        ]),
+                        Line::from(""),
+                    ])
+                })
+                .collect();
+
+            let list = ratatui::widgets::List::new(items).highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            );
+            f.render_stateful_widget(list, chunks[2], &mut list_state);
+        })?;
+
+        if let Event::Key(key) = event::read()? {
+            // Search mode: live-search as the user types
+            if searching {
+                match (key.code, key.modifiers) {
+                    (KeyCode::Esc, _) => {
+                        searching = false;
+                        query.clear();
+                        active_sessions = sessions.clone();
+                        selected = 0;
+                        continue;
+                    }
+                    (KeyCode::Enter, _) => {
+                        searching = false;
+                        continue;
+                    }
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                    (KeyCode::Backspace, _) => { query.pop(); }
+                    (KeyCode::Char(c), _) => { query.push(c); }
+                    _ => {}
+                }
+                // Live search: update results as the user types (>= 3 chars)
+                if query.chars().count() >= 3 {
+                    let engine = search_engine.get_or_insert_with(|| {
+                        let device = witchcraft::make_device();
+                        let embedder = witchcraft::Embedder::new(&device, assets).unwrap();
+                        let db = DB::new_reader(db_name.clone()).unwrap();
+                        (embedder, db)
+                    });
+                    if let Ok((search_results, _)) = run_search_with(
+                        &engine.1, &engine.0, &query, None, branch_filter, &[], None,
+                    ) {
+                        active_sessions = results_to_sessions(&search_results);
+                        selected = 0;
+                    }
+                } else if query.is_empty() {
+                    active_sessions = sessions.clone();
+                    selected = 0;
+                }
+                continue;
+            }
+
+            match (key.code, key.modifiers) {
+                (KeyCode::Char('q'), _) => break,
+                (KeyCode::Esc, _) => {
+                    if !query.is_empty() {
+                        query.clear();
+                        active_sessions = sessions.clone();
+                        selected = 0;
+                    } else {
+                        break;
+                    }
+                }
+                (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                (KeyCode::Char('f'), KeyModifiers::CONTROL) |
+                (KeyCode::Char('/'), _) => {
+                    searching = true;
+                }
+                (KeyCode::Down | KeyCode::Char('j'), _) => {
+                    if !active_sessions.is_empty() && selected + 1 < active_sessions.len() {
+                        selected += 1;
+                        list_state.select(Some(selected));
+                    }
+                }
+                (KeyCode::Up | KeyCode::Char('k'), _) => {
+                    if selected > 0 {
+                        selected -= 1;
+                        list_state.select(Some(selected));
+                    }
+                }
+                (KeyCode::Enter, _) => {
+                    if selected < active_sessions.len() {
+                        chosen = Some(selected);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    crossterm::execute!(std::io::stdout(), LeaveAlternateScreen)?;
+
+    if let Some(idx) = chosen {
+        let s = &active_sessions[idx];
+        if !std::path::Path::new(&s.path).exists() {
+            anyhow::bail!("session file no longer exists: {}", s.path);
+        }
+        launch_resume(&s.session_id, &s.source, &s.branch, &s.cwd)?;
+    }
+    Ok(())
+}
+
+fn resume_for_branch(db_name: &PathBuf, assets: &PathBuf, branch: &str) -> Result<()> {
+    let sessions = find_sessions_for_branch(db_name, branch)?;
+    pick_and_resume(sessions, &format!("on branch '{branch}'"), db_name, assets, Some(branch))
+}
+
+fn find_sessions_for_project(db_name: &PathBuf, cwd: &str) -> Result<Vec<BranchSession>> {
+    let db = DB::new_reader(db_name.clone()).unwrap();
+    let mut stmt = db.query(
+        "SELECT metadata, body, date FROM document
+         WHERE json_extract(metadata, '$.session_id') IS NOT NULL
+         ORDER BY date DESC",
+    )?;
+    let rows: Vec<(String, String, String)> = stmt
+        .query_map((), |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut seen = std::collections::HashSet::new();
+    let mut sessions = Vec::new();
+
+    // Claude Code stores the full cwd (sans leading /) as "project".
+    // Codex stores just the directory basename as "project" but has a
+    // separate "cwd" field with the full path. Match against both.
+    let cwd_canonical = cwd.trim_start_matches('/');
+
+    for (metadata, body, date) in &rows {
+        let meta: serde_json::Value = serde_json::from_str(metadata).unwrap_or_default();
+        let sid = meta["session_id"].as_str().unwrap_or("").to_string();
+        if sid.is_empty() || !seen.insert(sid.clone()) {
+            continue;
+        }
+        let project = meta["project"].as_str().unwrap_or("");
+        let meta_cwd = meta["cwd"].as_str().unwrap_or("").trim_start_matches('/');
+        if project != cwd_canonical && meta_cwd != cwd_canonical {
+            continue;
+        }
+        let title = body
+            .lines()
+            .find(|l| l.starts_with("[User]"))
+            .map(|l| l.strip_prefix("[User] ").unwrap_or(l))
+            .unwrap_or("")
+            .chars()
+            .take(80)
+            .collect::<String>();
+        sessions.push(BranchSession {
+            session_id: sid,
+            session_name: meta["session_name"].as_str().unwrap_or("").to_string(),
+            source: meta["source"].as_str().unwrap_or("claude").to_string(),
+            path: meta["path"].as_str().unwrap_or("").to_string(),
+            project: meta["project"].as_str().unwrap_or("").to_string(),
+            branch: meta["branch"].as_str().unwrap_or("").to_string(),
+            cwd: meta["cwd"].as_str().unwrap_or("").to_string(),
+            date: date.clone(),
+            title,
+        });
+    }
+    Ok(sessions)
+}
+
+fn resume_for_project(db_name: &PathBuf, assets: &PathBuf, cwd: &str) -> Result<()> {
+    let sessions = find_sessions_for_project(db_name, cwd)?;
+    pick_and_resume(sessions, &format!("in '{cwd}'"), db_name, assets, None)
 }
 
 fn format_date(iso: &str) -> String {
@@ -927,10 +1527,12 @@ fn main() -> Result<()> {
 
     let args: Vec<String> = env::args().skip(1).collect();
     let mut session_filter: Option<String> = None;
+    let mut branch_filter: Option<String> = None;
     let mut exclude_sessions: Vec<String> = Vec::new();
     let mut since_ms: Option<i64> = None;
     let mut dump_session: Option<String> = None;
     let mut turns_range: Option<String> = None;
+    let mut do_resume = false;
     let mut query_args: Vec<&str> = Vec::new();
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -949,6 +1551,9 @@ fn main() -> Result<()> {
             }
             "--session" => {
                 session_filter = iter.next().cloned();
+            }
+            "--branch" => {
+                branch_filter = iter.next().cloned();
             }
             "--exclude" => {
                 if let Some(val) = iter.next() {
@@ -976,6 +1581,9 @@ fn main() -> Result<()> {
             }
             "--turns" => {
                 turns_range = iter.next().cloned();
+            }
+            "--resume" => {
+                do_resume = true;
             }
             _ => {
                 query_args.push(arg);
@@ -1018,19 +1626,146 @@ fn main() -> Result<()> {
 
     if let Some(ref sid) = dump_session {
         dump(&db_name, sid, turns_range.as_deref())?;
+    } else if do_resume {
+        // --resume: find sessions by branch (or by project dir if not in a git repo)
+        if let Some(ref br) = branch_filter {
+            resume_for_branch(&db_name, &assets, br)?;
+        } else if let Some(br) = current_git_branch() {
+            resume_for_branch(&db_name, &assets, &br)?;
+        } else {
+            // Not in a git repo — fall back to sessions for the current project directory
+            let cwd = std::env::current_dir()?.to_string_lossy().to_string();
+            resume_for_project(&db_name, &assets, &cwd)?;
+        }
     } else if !query_args.is_empty() {
         let q = query_args.join(" ");
         if std::io::stdout().is_terminal() {
-            if let Some((sid, path, source)) = search_tui(&db_name, &assets, &q, session_filter.as_deref(), &exclude_sessions, since_ms)? {
-                launch_resume(&sid, &path, &source)?;
+            if let Some((sid, source, branch, cwd, _path)) = search_tui(&db_name, &assets, &q, session_filter.as_deref(), branch_filter.as_deref(), &exclude_sessions, since_ms)? {
+                launch_resume(&sid, &source, &branch, &cwd)?;
             }
         } else {
-            search_plain(&db_name, &assets, &q, session_filter.as_deref(), &exclude_sessions, since_ms)?;
+            search_plain(&db_name, &assets, &q, session_filter.as_deref(), branch_filter.as_deref(), &exclude_sessions, since_ms)?;
         }
     } else {
-        eprintln!("Usage: pickbrain [--session UUID] [--exclude UUID,...] [--since 24h|7d|2w] <query>");
+        eprintln!("Usage: pickbrain [--branch NAME] [--session UUID] [--exclude UUID,...] [--since 24h|7d|2w] <query>");
+        eprintln!("       pickbrain --resume [--branch NAME]");
         eprintln!("       pickbrain --dump <UUID> [--turns N-M]");
         eprintln!("       pickbrain --nuke");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_date() {
+        assert_eq!(format_date("2025-01-15T10:30:00Z"), "Jan 15 10:30");
+        assert_eq!(format_date("bad"), "??? ?? ??:??");
+    }
+
+    #[test]
+    fn test_parse_range() {
+        assert_eq!(parse_range("3-7"), (3, 7));
+        assert_eq!(parse_range("5"), (5, 5));
+    }
+
+    #[test]
+    fn test_build_sql_filter_none() {
+        assert!(build_sql_filter(None, None, &[], None).is_none());
+    }
+
+    #[test]
+    fn test_build_sql_filter_branch_only() {
+        use witchcraft::types::*;
+        let f = build_sql_filter(None, Some("main"), &[], None).unwrap();
+        assert_eq!(f.statement_type, SqlStatementType::Condition);
+        let cond = f.condition.unwrap();
+        assert_eq!(cond.key, "$.branch");
+    }
+
+    #[test]
+    fn test_build_sql_filter_both() {
+        use witchcraft::types::*;
+        let f = build_sql_filter(Some("abc"), Some("main"), &[], None).unwrap();
+        assert_eq!(f.statement_type, SqlStatementType::Group);
+        assert_eq!(f.logic, Some(SqlLogic::And));
+        assert_eq!(f.statements.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_results_to_sessions_deduplicates() {
+        let results = vec![
+            SearchResult {
+                timestamp: "Jan 15 10:30".to_string(),
+                project: "server".to_string(),
+                session_id: "abc-123".to_string(),
+                session_name: "debug".to_string(),
+                turn: 0,
+                path: "/tmp/test.jsonl".to_string(),
+                cwd: "/home/user/src/server".to_string(),
+                source: "claude".to_string(),
+                branch: "main".to_string(),
+                bodies: vec!["header".to_string(), "[User] first message".to_string()],
+                match_idx: 1,
+                turns: vec![],
+            },
+            SearchResult {
+                timestamp: "Jan 15 10:35".to_string(),
+                project: "server".to_string(),
+                session_id: "abc-123".to_string(), // same session
+                session_name: "debug".to_string(),
+                turn: 1,
+                path: "/tmp/test.jsonl".to_string(),
+                cwd: "/home/user/src/server".to_string(),
+                source: "claude".to_string(),
+                branch: "main".to_string(),
+                bodies: vec!["header".to_string(), "[User] second message".to_string()],
+                match_idx: 1,
+                turns: vec![],
+            },
+            SearchResult {
+                timestamp: "Jan 15 11:00".to_string(),
+                project: "server".to_string(),
+                session_id: "def-456".to_string(), // different session
+                session_name: "refactor".to_string(),
+                turn: 0,
+                path: "/tmp/test2.jsonl".to_string(),
+                cwd: "/home/user/src/server".to_string(),
+                source: "claude".to_string(),
+                branch: "main".to_string(),
+                bodies: vec!["header".to_string(), "[User] other work".to_string()],
+                match_idx: 1,
+                turns: vec![],
+            },
+        ];
+        let sessions = results_to_sessions(&results);
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_id, "abc-123");
+        assert_eq!(sessions[0].title, "first message"); // stripped [User] prefix
+        assert_eq!(sessions[1].session_id, "def-456");
+    }
+
+    #[test]
+    fn test_results_to_sessions_skips_empty_session_id() {
+        let results = vec![
+            SearchResult {
+                timestamp: "Jan 15 10:30".to_string(),
+                project: "server".to_string(),
+                session_id: "".to_string(), // e.g. .md file
+                session_name: "".to_string(),
+                turn: 0,
+                path: "/tmp/test.md".to_string(),
+                cwd: "".to_string(),
+                source: "claude".to_string(),
+                branch: "".to_string(),
+                bodies: vec!["some content".to_string()],
+                match_idx: 0,
+                turns: vec![],
+            },
+        ];
+        let sessions = results_to_sessions(&results);
+        assert!(sessions.is_empty());
+    }
 }

--- a/skills/pickbrain/SKILL.md
+++ b/skills/pickbrain/SKILL.md
@@ -51,6 +51,12 @@ To search within a specific session:
 pickbrain --session <session-id> "<query>"
 ```
 
+To filter by git branch:
+
+```bash
+pickbrain --branch <branch-name> "<query>"
+```
+
 To exclude specific sessions from results (comma-separated or repeated):
 
 ```bash


### PR DESCRIPTION
Pickbrain was close but didn't quite match my workflow since it is often branch based.  This adds 2 flags

1. `--resume` without a branch will use the current branch or cwd and present a list of conversations. This allows me to find the one with the right context for responding to PR comments.
2. `--branch X` when used alone, it will filter the conversations by branch and allow a normal pickbrain search.
3. `--resume --branch X` when used with resume, it will search as that branch.  When an option is selected, it will change the cwd and checkout the target branch to resume the conversations.
4. Inside the conversation picker `/` (or `ctrl-F`) allows a witchcraft search to further narrow the options (also works in the standard pickbrain UI)
5. Fixed a bug where we rescanned the entire conversation to find the cwd which made restarting very slow.

Lots of unit tests.