### PR TITLE
fix stale docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 target
 warp.node
+warp-cli
+pickbrain
+.claude/
 
 # Uncompressed OpenVINO model files (large, not versioned)
 assets/*

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ module:
 	cargo build --release --target aarch64-apple-darwin --features t5-quantized,metal,napi
 	cargo build --release --target x86_64-apple-darwin --features t5-quantized,fbgemm,hybrid-dequant,napi
 	lipo -create target/aarch64-apple-darwin/release/libwitchcraft.dylib target/x86_64-apple-darwin/release/libwitchcraft.dylib -output target/release/warp-macos-universal.node
+	ln -sf target/release/warp-macos-universal.node warp.node
 
 test: download
 	RUST_LOG=debug cargo llvm-cov nextest --release --features napi,$(CLI_FEATURES) --lcov --output-path lcov.info

--- a/README.md
+++ b/README.md
@@ -90,16 +90,15 @@ When building, exactly one T5 backend must be enabled:
 
 Other flags:
 - `metal` -- macOS GPU acceleration (Apple Silicon only)
-- `accelerate` -- macOS BLAS via Accelerate framework
 - `fbgemm` -- fbgemm-rs packed GEMM (bf16 weights, faster on x86)
 - `hybrid-dequant` -- F32 attention + Q4K FFN with fused gated-gelu (x86, requires `fbgemm`)
 - `napi` -- Node.js native module via napi-rs
 - `embed-assets` -- bake weights into binary
 - `progress` -- progress bars for CLI
 
-Platform-specific recommended features:
-- **Apple Silicon**: `t5-quantized,metal,accelerate`
-- **Intel Mac (x86_64)**: `t5-quantized,accelerate,hybrid-dequant,fbgemm`
+Platform-specific recommended features (these are what `make` uses automatically):
+- **Apple Silicon**: `t5-quantized,metal`
+- **Intel Mac (x86_64)**: `t5-quantized,fbgemm,hybrid-dequant`
 - **Intel Windows (x86_64)**: `t5-openvino,fbgemm`
 
 ## Using as Node module ##
@@ -107,8 +106,22 @@ Platform-specific recommended features:
 ```
 make module
 ```
-Builds target/release/warp.node. Which loads the compressed weights from the
-"assets" dir.
+Builds a universal macOS binary at `target/release/warp-macos-universal.node`
+(lipo'd from aarch64 + x86_64 builds with platform-appropriate features).
+
+To use in another project:
+
+```
+cd /path/to/your-project
+npm install /path/to/witchcraft
+```
+
+Then in JavaScript:
+
+```js
+const { Witchcraft } = require('warp');
+const wc = new Witchcraft('/path/to/db.sqlite', '/path/to/assets');
+```
 
 ## Unit tests and Code Coverage
 

--- a/install.cjs
+++ b/install.cjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -7,29 +6,27 @@ const exec = util.promisify(require('child_process').exec);
 async function run(command) {
   console.log(`running: ${command} ...`);
   const { stdout, stderr } = await exec(command);
-  console.log(stdout);
-  console.error(stderr);
+  if (stdout) console.log(stdout);
+  if (stderr) console.error(stderr);
 }
 
 async function build(platform, arch) {
   if (platform == 'darwin') {
-    await run(`cargo build --locked --release --target aarch64-apple-darwin --features accelerate`);
-    await run(`cargo build --locked --release --target x86_64-apple-darwin --features accelerate`);
-	await run(`lipo -create target/aarch64-apple-darwin/release/libwarp.dylib target/x86_64-apple-darwin/release/libwarp.dylib -output warp.node`);
+    await run(`cargo build --release --target aarch64-apple-darwin --features t5-quantized,metal,napi`);
+    await run(`cargo build --release --target x86_64-apple-darwin --features t5-quantized,fbgemm,hybrid-dequant,napi`);
+    await run(`lipo -create target/aarch64-apple-darwin/release/libwitchcraft.dylib target/x86_64-apple-darwin/release/libwitchcraft.dylib -output warp.node`);
   } else if (platform == 'win32') {
     var target = "";
     if (arch == "x64") {
       target = "x86_64";
-    } else if (arch == "ia32") {
-	  target = "i686";
     } else if (arch == "arm64") {
-	  target = "aarch64";
+      target = "aarch64";
     } else {
-      console.error(`unsupported warp target ${platform} ${arch}`);
+      console.error(`unsupported target ${platform} ${arch}`);
       return;
     }
-	await run(`cargo build --locked --release --target ${target}-pc-windows-msvc`);
-	await run(`cp target/${target}-pc-windows-msvc/release/warp.dll warp.node`);
+    await run(`cargo build --release --target ${target}-pc-windows-msvc --features t5-openvino,fbgemm,napi`);
+    await run(`cp target/${target}-pc-windows-msvc/release/witchcraft.dll warp.node`);
   }
 }
 
@@ -37,8 +34,8 @@ const platform = process.env.npm_config_platform || process.platform;
 const arch = process.env.npm_config_arch || process.arch;
 
 if (process.env.ENABLE_WARP == '1') {
-  console.log(`building Warp module for ${platform} ${arch}`);
+  console.log(`building witchcraft native module for ${platform} ${arch}`);
   build(platform, arch);
 } else {
-  console.log(`Not building Warp, set ENABLE_WARP=1 in environment to enable`);
+  console.log(`Not building native module, set ENABLE_WARP=1 in environment to enable`);
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "index.cjs",
   "files": [
     "index.cjs",
+    "install.cjs",
     "warp.node",
     "assets/LICENSE.txt",
-    "assets/config.json.zst",
-    "assets/tokenizer.json.zst",
-    "assets/xtr.gguf.zst"
+    "assets/config.json",
+    "assets/tokenizer.json",
+    "assets/xtr.gguf"
   ],
   "packageManager": "yarn@4.9.2",
   "scripts": {

--- a/scifact-score.sh
+++ b/scifact-score.sh
@@ -1,5 +1,5 @@
 rm -rf output.txt
 
-cargo run --release --features accelerate querycsv $HOME/src/xtr-warp/beir/scifact/questions.test.tsv output.txt &&\
+cargo run --release --features t5-quantized,metal querycsv $HOME/src/xtr-warp/beir/scifact/questions.test.tsv output.txt &&\
 
 python score.py output.txt $HOME/src/xtr-warp/beir/scifact/collection_map.json $HOME/src/xtr-warp/beir/scifact/qrels.test.json

--- a/tools/compare-spotlight-warp.sh
+++ b/tools/compare-spotlight-warp.sh
@@ -17,7 +17,7 @@ echo
 # Check prerequisites
 if [ ! -f "$WARP_CLI" ]; then
     echo "Error: warp-cli not found at $WARP_CLI"
-    echo "Build with: cargo build --release --features t5-quantized,metal,accelerate --bin warp-cli"
+    echo "Build with: make warp-cli"
     exit 1
 fi
 


### PR DESCRIPTION
  The accelerate feature was removed from the main crate a while back, but references to it survived in the README, install.cjs, and benchmark scripts. Meanwhile  install.cjs still referenced the old libwarp.dylib name and package.json listed .zst compressed assets that don't exist. Running make module also didn't  produce a usable warp.node — you had to know to run make run or manually symlink.

##  Changes

- Remove stale accelerate references from README feature docs, recommended platform features, install.cjs, scifact-score.sh, and compare-spotlight-warp.sh
- Fix install.cjs — correct dylib/dll names (libwitchcraft/witchcraft), add current per-platform features (metal, fbgemm, hybrid-dequant, napi), drop dead ia32 target
- Fix package.json files list — reference actual asset names (not .zst), include install.cjs
- Fix make module — add warp.node symlink so npm install works immediately after build
- Expand README node module section — document npm install from another project with JS usage example
- Add warp-cli, pickbrain, .claude/ to .gitignore