### PR TITLE
Fix scoring off-by-one, temp table leak, and embed error swallowing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,32 +984,41 @@ pub fn match_centroids(
     )?;
     let mut insert_temp_query = db.query("INSERT INTO temp2 VALUES(?1, ?2, ?3)")?;
 
-    let mut prev_idx = u32::MAX;
-    let mut prev_sub_idx = u32::MAX;
+    let mut prev_idx = 0u32;
+    let mut prev_sub_idx = 0u32;
 
     let scaler = 1.0f32 / n as f32;
-    for i in 0..all.len() {
-        let ((idx, sub_idx), pos) = all[i];
-        let is_last = i == all.len() - 1;
+    for i in 0.. {
 
-        let idx_change = prev_idx != idx;
-        let sub_idx_change = idx_change || prev_sub_idx != sub_idx;
+        let is_beyond_end = i == all.len();
+        let ((idx, sub_idx), pos) = if is_beyond_end {
+            ((u32::MAX, u32::MAX), 0)
+        } else {
+            all[i]
+        };
 
-        // Flush previous sub-document / document scores on boundary change
-        if i > 0 && (sub_idx_change || is_last) {
-            let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
-            if sub_score > cutoff {
-                let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
+        if i > 0 {
+            let idx_change = prev_idx != idx;
+            let sub_idx_change = idx_change || prev_sub_idx != sub_idx;
+
+            if sub_idx_change {
+                let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
+                if sub_score > cutoff {
+                    let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
+                }
+                vmax_inplace(&mut doc_scores, &sub_scores);
+                sub_scores.copy_from_slice(&doc_scores);
             }
-            vmax_inplace(&mut doc_scores, &sub_scores);
-            sub_scores.copy_from_slice(&doc_scores);
-        }
-        if i > 0 && (idx_change || is_last) {
-            doc_scores.copy_from_slice(&missing_similarities);
-            sub_scores.copy_from_slice(&missing_similarities);
+            if idx_change {
+                doc_scores.copy_from_slice(&missing_similarities);
+                sub_scores.copy_from_slice(&missing_similarities);
+            }
         }
 
-        // Accumulate CURRENT element's scores (including the last one)
+        if is_beyond_end {
+            break;
+        }
+
         let row = row_at(pos);
         vmax_inplace(&mut sub_scores, row);
 
@@ -1017,14 +1026,6 @@ pub fn match_centroids(
         assert!(i == 0 || (prev_idx != idx || prev_sub_idx <= sub_idx));
         prev_idx = idx;
         prev_sub_idx = sub_idx;
-    }
-
-    // Flush the final element
-    if !all.is_empty() {
-        let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
-        if sub_score > cutoff {
-            let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
-        }
     }
 
     let (filter_sql, filter_params) = build_filter_sql_and_params(sql_filter)?;
@@ -1321,7 +1322,6 @@ pub fn embed_chunks(db: &DB, embedder: &Embedder, limit: Option<usize>) -> Resul
                 progress.inc(1);
             }
             Err(v) => {
-                progress.finish();
                 return Err(anyhow::anyhow!("add_chunk failed: {v}"));
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -978,6 +978,7 @@ pub fn match_centroids(
     let mut doc_scores = vec![0.0f32; n];
     doc_scores.copy_from_slice(&missing_similarities);
 
+    db.execute("DROP TABLE IF EXISTS temp2")?;
     db.execute(
         "CREATE TEMPORARY TABLE temp2(rowid INTEGER, sub_idx INTEGER, score FLOAT, UNIQUE(rowid, sub_idx))",
     )?;
@@ -987,33 +988,28 @@ pub fn match_centroids(
     let mut prev_sub_idx = u32::MAX;
 
     let scaler = 1.0f32 / n as f32;
-    for i in 0.. {
+    for i in 0..all.len() {
         let ((idx, sub_idx), pos) = all[i];
-
         let is_last = i == all.len() - 1;
 
         let idx_change = prev_idx != idx;
         let sub_idx_change = idx_change || prev_sub_idx != sub_idx;
 
-        if i > 0 {
-            if sub_idx_change || is_last {
-                let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
-                if sub_score > cutoff {
-                    let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
-                }
-                vmax_inplace(&mut doc_scores, &sub_scores);
-                sub_scores.copy_from_slice(&doc_scores);
+        // Flush previous sub-document / document scores on boundary change
+        if i > 0 && (sub_idx_change || is_last) {
+            let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
+            if sub_score > cutoff {
+                let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
             }
-            if idx_change || is_last {
-                doc_scores.copy_from_slice(&missing_similarities);
-                sub_scores.copy_from_slice(&missing_similarities);
-            }
+            vmax_inplace(&mut doc_scores, &sub_scores);
+            sub_scores.copy_from_slice(&doc_scores);
+        }
+        if i > 0 && (idx_change || is_last) {
+            doc_scores.copy_from_slice(&missing_similarities);
+            sub_scores.copy_from_slice(&missing_similarities);
         }
 
-        if is_last {
-            break;
-        }
-
+        // Accumulate CURRENT element's scores (including the last one)
         let row = row_at(pos);
         vmax_inplace(&mut sub_scores, row);
 
@@ -1021,6 +1017,14 @@ pub fn match_centroids(
         assert!(i == 0 || (prev_idx != idx || prev_sub_idx <= sub_idx));
         prev_idx = idx;
         prev_sub_idx = sub_idx;
+    }
+
+    // Flush the final element
+    if !all.is_empty() {
+        let sub_score = scaler * (sub_scores.iter().copied().sum::<f32>());
+        if sub_score > cutoff {
+            let _ = insert_temp_query.execute((prev_idx, prev_sub_idx, sub_score));
+        }
     }
 
     let (filter_sql, filter_params) = build_filter_sql_and_params(sql_filter)?;
@@ -1317,8 +1321,8 @@ pub fn embed_chunks(db: &DB, embedder: &Embedder, limit: Option<usize>) -> Resul
                 progress.inc(1);
             }
             Err(v) => {
-                warn!("add_chunk failed {}", v);
-                break;
+                progress.finish();
+                return Err(anyhow::anyhow!("add_chunk failed: {v}"));
             }
         };
     }
@@ -1385,7 +1389,7 @@ fn run_kmeans_for_index(matrix: &Tensor, total_embeddings: usize) -> Result<Tens
     debug!("total_embeddings={} k={}", total_embeddings, k);
     let (m, _) = matrix.dims2()?;
     if m < k {
-        k = m / 4;
+        k = (m / 4).max(1);
     }
     let centers = kmeans(matrix, k, 5)?;
     debug!("kmeans took {} ms.", now.elapsed().as_millis());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -430,4 +430,35 @@ mod tests {
         db.shutdown();
         Ok(())
     }
+
+    /// Regression test for scoring off-by-one: the last token vector was
+    /// dropped because vmax_inplace was unreachable after the break.
+    /// A single-document corpus exercises this: the one document is both
+    /// the first and last element in the scoring loop.
+    #[test]
+    fn test_single_doc_search() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("single_doc.sqlite");
+        let assets = PathBuf::from("assets");
+        // Use CPU to avoid Metal buffer contention in parallel test runs
+        let device = candle_core::Device::Cpu;
+        let embedder = crate::Embedder::new(&device, &assets)?;
+        let mut cache = crate::EmbeddingsCache::new(4);
+
+        let mut db = DB::new(path.clone())?;
+        let uuid = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"only-doc");
+        db.add_doc(&uuid, None, &uuid.to_string(), "Honey never spoils", None)?;
+        crate::embed_chunks(&db, &embedder, None)?;
+        crate::index_chunks(&db, &device)?;
+
+        let results = crate::search(
+            &db, &embedder, &mut cache,
+            "honey preservation", 0.3, 10, false, None,
+        )?;
+        assert!(!results.is_empty(), "single-doc search must return the document");
+
+        db.clear();
+        db.shutdown();
+        Ok(())
+    }
 }


### PR DESCRIPTION
1. Scoring loop off-by-one: the last token vector in the sorted list was never accumulated into sub_scores because the break fired before vmax_inplace. Restructured to accumulate then flush, with a final flush after the loop.

2. Temp table leak: added DROP TABLE IF EXISTS before CREATE TEMPORARY TABLE temp2. Prevents accumulation if a previous search errored.

3. embed_chunks error swallowing: add_chunk failures now return Err instead of logging a warning and returning Ok(count).