### PR TITLE
Skip empty-body docs, remove redundant indexes, add batch insert

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -33,7 +33,7 @@ impl DB {
 
     pub fn new(db_fn: PathBuf) -> SQLResult<Self> {
         const APP_ID: i32 = 0x07DB_DA55;
-        const EXPECTED_VERSION: i32 = 6;
+        const EXPECTED_VERSION: i32 = 7;
 
         let mut first_creation = !db_fn.exists();
         let connection = Connection::open(&db_fn)?;
@@ -94,9 +94,6 @@ impl DB {
         );
         connection.execute(&query, ())?;
 
-        let query = "CREATE INDEX IF NOT EXISTS document_uuid_index ON document(uuid)";
-        connection.execute(query, ())?;
-
         let query = "CREATE INDEX IF NOT EXISTS document_index ON document(hash)";
         connection.execute(query, ())?;
 
@@ -115,8 +112,6 @@ impl DB {
         );
         connection.execute(&query, ())?;
 
-        let query = "CREATE INDEX IF NOT EXISTS chunk_index ON chunk(hash)";
-        connection.execute(query, ())?;
 
         let query = "CREATE TRIGGER IF NOT EXISTS document_after_delete
             AFTER DELETE ON document
@@ -279,45 +274,63 @@ impl DB {
         body: &str,
         lens: Option<Vec<usize>>,
     ) -> SQLResult<()> {
-        let lens = match lens {
-            Some(lens) => lens,
-            None => [body.chars().count()].to_vec(),
-        };
+        self.add_docs_batch(&[(*uuid, date, metadata, body, lens)])?;
+        Ok(())
+    }
 
-        let total: usize = lens.iter().copied().sum();
-        if total != body.chars().count() {
-            warn!("bad length: [{} vs {}]", total, body.chars().count());
+    /// Batch-add documents in a single transaction. Prepares the statement once
+    /// and reuses it for all inserts. Much faster than individual add_doc calls.
+    pub fn add_docs_batch(
+        &mut self,
+        docs: &[(Uuid, Option<Timestamp>, &str, &str, Option<Vec<usize>>)],
+    ) -> SQLResult<usize> {
+        if docs.is_empty() {
+            return Ok(0);
         }
-
-        let lens = lens
-            .iter()
-            .map(|len| len.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-
-        let mut hasher = Sha256::new();
-        hasher.update(body);
-        hasher.update(&lens);
-        let hash = format!("{:x}", hasher.finalize());
-        let hash = &hash[..HASH_CHARS];
-
-        let date = date.unwrap_or_else(Timestamp::now_utc);
-
-        self.conn().execute(
+        self.conn().execute("BEGIN", ())?;
+        let mut stmt = self.conn().prepare(
             "INSERT INTO document VALUES(?1, ?2, ?3, ?4, ?5, ?6)
             ON CONFLICT(uuid) DO UPDATE SET
                 date = ?2, metadata = ?3, hash = ?4, body = ?5, lens = ?6",
-            (
+        )?;
+
+        let mut count = 0;
+        for (uuid, date, metadata, body, lens) in docs {
+            let lens = match lens {
+                Some(lens) => lens.clone(),
+                None => vec![body.chars().count()],
+            };
+            let total: usize = lens.iter().copied().sum();
+            if total != body.chars().count() {
+                warn!("bad length: [{} vs {}]", total, body.chars().count());
+            }
+            let lens_str = lens
+                .iter()
+                .map(|len| len.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+
+            let mut hasher = Sha256::new();
+            hasher.update(body.as_bytes());
+            hasher.update(lens_str.as_bytes());
+            let hash = format!("{:x}", hasher.finalize());
+            let hash = &hash[..HASH_CHARS];
+
+            let date = date.unwrap_or_else(Timestamp::now_utc);
+            stmt.execute((
                 &uuid.to_string(),
                 date.to_string(),
-                metadata,
-                &hash,
-                &body,
-                &lens,
-            ),
-        )?;
+                *metadata,
+                hash,
+                *body,
+                &lens_str,
+            ))?;
+            count += 1;
+        }
+        drop(stmt);
+        self.conn().execute("COMMIT", ())?;
         self.remove_on_shutdown = false;
-        Ok(())
+        Ok(count)
     }
 
     pub fn remove_doc(&mut self, uuid: &Uuid) -> SQLResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1247,7 +1247,7 @@ pub fn embed_chunks(db: &DB, embedder: &Embedder, limit: Option<usize>) -> Resul
         let count_sql = format!(
             "SELECT COUNT(*) FROM document
             LEFT JOIN chunk ON document.hash = chunk.hash
-            WHERE chunk.hash IS NULL
+            WHERE chunk.hash IS NULL AND length(document.body) > 0
             {}",
             match limit {
                 Some(limit) => format!("LIMIT {limit}"),
@@ -1264,7 +1264,7 @@ pub fn embed_chunks(db: &DB, embedder: &Embedder, limit: Option<usize>) -> Resul
         document.hash,document.body,document.lens
         FROM document
         LEFT JOIN chunk ON document.hash = chunk.hash
-        WHERE chunk.hash IS NULL
+        WHERE chunk.hash IS NULL AND length(document.body) > 0
         ORDER BY document.hash
         {}",
         match limit {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -430,4 +430,110 @@ mod tests {
         db.shutdown();
         Ok(())
     }
+
+    #[test]
+    fn test_add_docs_batch() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("batch_test.sqlite");
+        let mut db = DB::new(path)?;
+
+        let docs: Vec<(Uuid, Option<iso8601_timestamp::Timestamp>, &str, &str, Option<Vec<usize>>)> = vec![
+            (Uuid::new_v5(&Uuid::NAMESPACE_OID, b"doc1"), None, r#"{"title":"one"}"#, "first document body", None),
+            (Uuid::new_v5(&Uuid::NAMESPACE_OID, b"doc2"), None, r#"{"title":"two"}"#, "second document body", None),
+            (Uuid::new_v5(&Uuid::NAMESPACE_OID, b"doc3"), None, r#"{"title":"three"}"#, "third document body", None),
+        ];
+
+        let count = db.add_docs_batch(&docs)?;
+        assert_eq!(count, 3);
+
+        // Verify docs exist
+        let row_count: usize = db.query("SELECT COUNT(*) FROM document")?
+            .query_row((), |row| row.get(0))?;
+        assert_eq!(row_count, 3);
+
+        // Verify add_doc delegates to add_docs_batch correctly
+        let uuid4 = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"doc4");
+        db.add_doc(&uuid4, None, r#"{"title":"four"}"#, "fourth body", None)?;
+        let row_count: usize = db.query("SELECT COUNT(*) FROM document")?
+            .query_row((), |row| row.get(0))?;
+        assert_eq!(row_count, 4);
+
+        // Verify upsert: re-add doc1 with different body
+        let uuid1 = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"doc1");
+        db.add_doc(&uuid1, None, r#"{"title":"one-updated"}"#, "updated body", None)?;
+        let row_count: usize = db.query("SELECT COUNT(*) FROM document")?
+            .query_row((), |row| row.get(0))?;
+        assert_eq!(row_count, 4); // still 4, not 5
+
+        let metadata: String = db.query("SELECT metadata FROM document WHERE uuid = ?1")?
+            .query_row((uuid1.to_string(),), |row| row.get(0))?;
+        assert!(metadata.contains("one-updated"));
+
+        db.clear();
+        db.shutdown();
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_body_not_embedded() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("empty_body_test.sqlite");
+        let assets = PathBuf::from("assets");
+        let mut db = DB::new(path.clone())?;
+        let device = crate::make_device();
+        let embedder = crate::Embedder::new(&device, &assets)?;
+
+        // Add one doc with empty body and one with real content
+        let uuid_empty = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"empty");
+        let uuid_real = Uuid::new_v5(&Uuid::NAMESPACE_OID, b"real");
+        db.add_doc(&uuid_empty, None, "{}", "", None)?;
+        db.add_doc(&uuid_real, None, "{}", "Octopuses have three hearts", None)?;
+
+        let count = crate::embed_chunks(&db, &embedder, None)?;
+        assert_eq!(count, 1, "only the non-empty doc should be embedded");
+
+        // Verify the chunk table has exactly one entry
+        let chunk_count: usize = db.query("SELECT COUNT(*) FROM chunk")?
+            .query_row((), |row| row.get(0))?;
+        assert_eq!(chunk_count, 1);
+
+        db.clear();
+        db.shutdown();
+        Ok(())
+    }
+
+    #[test]
+    fn test_redundant_indexes_dropped() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("index_test.sqlite");
+
+        // First open creates the schema (with DROP IF EXISTS for old indexes)
+        let mut db = DB::new(path.clone())?;
+        db.add_doc(
+            &Uuid::new_v5(&Uuid::NAMESPACE_OID, b"test"),
+            None, "{}", "test body", None,
+        )?;
+
+        // Verify document_uuid_index does NOT exist (dropped)
+        let idx_count: usize = db.query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='document_uuid_index'"
+        )?.query_row((), |row| row.get(0))?;
+        assert_eq!(idx_count, 0, "document_uuid_index should be dropped");
+
+        // Verify chunk_index does NOT exist (dropped)
+        let idx_count: usize = db.query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='chunk_index'"
+        )?.query_row((), |row| row.get(0))?;
+        assert_eq!(idx_count, 0, "chunk_index should be dropped");
+
+        // Verify document_index (on hash, NOT a PK duplicate) still exists
+        let idx_count: usize = db.query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='document_index'"
+        )?.query_row((), |row| row.get(0))?;
+        assert_eq!(idx_count, 1, "document_index on hash should exist");
+
+        db.clear();
+        db.shutdown();
+        Ok(())
+    }
 }


### PR DESCRIPTION
1. embed_chunks: add AND length(document.body) > 0 to skip documents with empty bodies that produce no useful embeddings.

2. Drop document_uuid_index (duplicates uuid PK) and chunk_index (duplicates hash PK). Uses DROP IF EXISTS for safe migration of existing databases.

3. Add add_docs_batch: prepare-once execute-many in a single transaction. Avoids per-document statement preparation overhead for bulk inserts.