### PR TITLE
make_device: survive candle's empty-Metal-devices panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,17 +82,62 @@ const LSM_FANOUT: usize = 2;
 /// Allows precise location of results within subdivided documents
 pub type DocPtr = (u32, u32);
 
-pub fn make_device() -> Device {
-    // Metal only works on Apple Silicon (ARM), not Intel x86_64
-    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-        match Device::new_metal(0) {
-            Ok(device) => device,
-            Err(v) => {
-                warn!("unable to create metal device: {v}");
-                Device::Cpu
-            }
+/// Check `WITCHCRAFT_FORCE_CPU` for a truthy override. Accepts the usual
+/// truthy strings (`1`, `true`, `yes`, `on`, case-insensitive); any other
+/// value — including unset, empty, or `0`/`false`/`no`/`off` — leaves the
+/// default device-selection behaviour in place.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn force_cpu_from_env() -> bool {
+    match std::env::var("WITCHCRAFT_FORCE_CPU").ok().as_deref() {
+        Some(raw) => {
+            let v = raw.trim().to_ascii_lowercase();
+            !v.is_empty() && !matches!(v.as_str(), "0" | "false" | "no" | "off")
         }
-    } else {
+        None => false,
+    }
+}
+
+/// Probe Metal exactly once per process.
+///
+/// candle-core 0.10.1's `MetalDevice::new` calls
+/// `metal::Device::all().swap_remove(0)` unconditionally. When the OS
+/// returns an empty device list — e.g. inside sandboxed macOS processes
+/// (CI containers, the Claude Code Bash tool) even on M-series machines
+/// with a physical GPU — this panics instead of returning `Err`. Catch the
+/// unwind so the `Device::Cpu` fallback can actually fire. The first probe
+/// may emit a one-shot stderr trace from candle's own panic handler;
+/// memoizing via `OnceLock` keeps that to exactly once per process.
+///
+/// TODO: retire this guard once candle returns `Err` for empty device
+/// lists upstream (huggingface/candle).
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn probe_device() -> Device {
+    let result = std::panic::catch_unwind(|| Device::new_metal(0));
+    match result {
+        Ok(Ok(device)) => device,
+        Ok(Err(v)) => {
+            warn!("unable to create metal device: {v}");
+            Device::Cpu
+        }
+        Err(_) => {
+            warn!("metal device init panicked, falling back to CPU");
+            Device::Cpu
+        }
+    }
+}
+
+pub fn make_device() -> Device {
+    // Metal only works on Apple Silicon; every other target is CPU.
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        if force_cpu_from_env() {
+            return Device::Cpu;
+        }
+        static DEVICE: std::sync::OnceLock<Device> = std::sync::OnceLock::new();
+        DEVICE.get_or_init(probe_device).clone()
+    }
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    {
         Device::Cpu
     }
 }


### PR DESCRIPTION
## Summary

- candle 0.10.1's `MetalDevice::new` calls `metal::Device::all().swap_remove(0)` unconditionally, so when the OS returns an empty device list — e.g. inside sandboxed macOS processes (CI containers, Claude Code's Bash tool) even on M-series hardware with a physical GPU — it panics with `swap_remove index (is 0) should be < len (is 0)` instead of returning `Err`.
- The existing `match Device::new_metal(0) { Err => Cpu, … }` arm in `make_device` therefore never fires and the entire binary aborts. I hit this trying to run `pickbrain` from Claude Code's Bash tool on an M3 Pro.
- Fix: catch the unwind so the `Device::Cpu` fallback actually runs; memoize behind `OnceLock<Device>` so the probe happens once per process (also serialises the probe under napi/rayon, which call `make_device()` from multiple entry points).

## Additional changes

- Add `WITCHCRAFT_FORCE_CPU` env var for users who want to skip the probe entirely (e.g. to silence the one-shot stderr noise in sandboxed shells). Accepts the usual truthy strings (`1`, `true`, `yes`, `on`), case-insensitive.
- Gate the Metal probe behind a compile-time `#[cfg(all(target_os = \"macos\", target_arch = \"aarch64\"))]` so non-arm64 targets don't carry the dead code.

## Trade-off worth naming

Mutating the global panic hook to also silence the one-shot stderr trace would race with any other thread panicking during the probe window — not safe in a library, especially one that is consumed via napi and uses rayon internally. So I accepted the one-time noise rather than installing a process-global hook.

## Repro

Run any witchcraft-using binary inside a process whose macOS sandbox denies Metal device access. Before: immediate panic at startup. After: one \`[WARN] metal device init panicked, falling back to CPU\` line, fallback to CPU, everything continues.

## Test plan

- [x] Builds on aarch64 macOS with default features (\`make pickbrain\`)
- [x] Pickbrain search returns results from the Claude Code Bash-tool sandbox (which is where this issue first showed up) — confirmed on an ~2,000-session corpus
- [x] \`WITCHCRAFT_FORCE_CPU=true\` and \`=1\` skip the probe entirely (silent)
- [x] \`WITCHCRAFT_FORCE_CPU=0\`/\`false\`/unset preserve the default probing behaviour
- [ ] Not tested: Intel macOS / non-macOS targets (the new code is behind \`#[cfg]\` and compiles to the same \`Device::Cpu\` return as before)

## Upstream follow-up

The real fix lives in candle-core — \`MetalDevice::new\` should return \`Err\` for an empty device list rather than panicking. Happy to file an issue there if it would help land this; I wanted to get the PR open first.

Generated with [Claude Code](https://claude.com/claude-code)