### PR TITLE
Drop kmeans sample matrix before write_buckets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1224,6 +1224,7 @@ fn build_layer(
         level, total_embeddings, min_rowid, max_rowid
     );
     let centers = run_kmeans_for_index(&matrix, total_embeddings)?;
+    drop(matrix); // Free kmeans sample matrix before write_buckets
 
     let (tmpfiles, centers_cpu) =
         write_buckets_for_range(db, &centers, device, total_embeddings as u64, min_rowid, max_rowid)?;


### PR DESCRIPTION
build_layer holds the kmeans sample matrix alive through write_buckets_for_range, which reads all embeddings for bucket assignment. Both compete for memory on large corpora.

## Changes

- Explicit drop(matrix) after run_kmeans_for_index returns centers, freeing the sample matrix before the allocation-heavy bucket write pass