### PR TITLE
Bump candle pin to 5bd5618 for Metal device enumeration fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ anyhow = "*"
 serde = "*"
 serde_json = "*"
 
-candle-core = { git = "https://github.com/huggingface/candle", rev="0.10.1" }
-candle-nn = { git = "https://github.com/huggingface/candle", rev="0.10.1" }
-candle-transformers = { git = "https://github.com/huggingface/candle", rev="0.10.1" }
+candle-core = { git = "https://github.com/huggingface/candle", rev="5bd5618" }
+candle-nn = { git = "https://github.com/huggingface/candle", rev="5bd5618" }
+candle-transformers = { git = "https://github.com/huggingface/candle", rev="5bd5618" }
 
 tokenizers = "*"
 serde_plain = "1.0.2"
@@ -59,17 +59,17 @@ libc = "0.2"
 
 # Apple Silicon (ARM) - enable Metal support
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
-candle-core = { git = "https://github.com/huggingface/candle", rev="0.10.1", features = ["metal"] }
-candle-nn = { git = "https://github.com/huggingface/candle", rev="0.10.1", features = ["metal"] }
-candle-metal-kernels = { git = "https://github.com/huggingface/candle", rev="0.10.1", optional=true }
+candle-core = { git = "https://github.com/huggingface/candle", rev="5bd5618", features = ["metal"] }
+candle-nn = { git = "https://github.com/huggingface/candle", rev="5bd5618", features = ["metal"] }
+candle-metal-kernels = { git = "https://github.com/huggingface/candle", rev="5bd5618", optional=true }
 metal = { version = "0.27.0", features = ["mps"], optional = true }
 ug-metal = { version = "0.4.0", optional = true }
 libc = { version = "0.2.147", optional = true }
 
 # Intel (x86_64) - no Metal support, use Accelerate only
 [target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
-candle-core = { git = "https://github.com/huggingface/candle", rev="0.10.1", features = [] }
-candle-nn = { git = "https://github.com/huggingface/candle", rev="0.10.1", features = [] }
+candle-core = { git = "https://github.com/huggingface/candle", rev="5bd5618", features = [] }
+candle-nn = { git = "https://github.com/huggingface/candle", rev="5bd5618", features = [] }
 libc = { version = "0.2.147", optional = true }
 
 # Windows - priority management


### PR DESCRIPTION
## Summary

Bumps the candle git pin in `Cargo.toml` from `rev=\"0.10.1\"` to `rev=\"5bd5618\"` in all 8 places (workspace-level + target-specific blocks for aarch64-apple-darwin and x86_64-apple-darwin). `5bd5618` is the merge commit for huggingface/candle#3382 and includes the two relevant upstream fixes:

- **huggingface/candle#3449** (`c5d7d49`) — replaces `Device::all().swap_remove(0)` with `MTLCopyAllDevices()`, fixing the panic on Macs where the default Metal device enumerator returns an empty list (seen on M3 Pro). `MetalDevice::new` now returns `Err` instead of panicking when no device is available.
- **huggingface/candle#3382** (`5bd5618`) — removes `unwrap()`s from `candle-metal-kernels/src/metal/device.rs`, replacing them with proper `Result` propagation.

Cargo.lock moves candle-* from `0.10.1` → `0.10.2` (candle's post-release dev version). There is no newer tagged candle release yet — `0.10.1` is still latest — hence the SHA pin rather than a tag bump.

## Context

This supersedes #11 (the `catch_unwind` workaround) per @jacobgorm's review. Once this lands, #11 will be closed manually: `make_device` at `src/lib.rs:88` already matches on `Ok/Err` from `Device::new_metal(0)` and falls back to `Device::Cpu`, so the new Err-instead-of-panic behavior from #3449 is handled correctly by existing code — no workaround needed.

## Test plan

- [x] `cargo check --features t5-quantized,metal,progress --target aarch64-apple-darwin` — clean on M3 Pro
- [x] `cargo check --features t5-quantized --target x86_64-apple-darwin` — clean (cross-compile)
- [x] `cargo check --features t5-quantized,hybrid-dequant,progress --target x86_64-apple-darwin` — clean (cross-compile)
- [x] Verified that `make_device` (src/lib.rs:85-98) already handles `Device::new_metal` errors via CPU fallback — new candle behavior slots in cleanly.
- [ ] Linux build — not verified locally; no Linux-specific churn in the 23-commit range `0.10.1..5bd5618`. Worth a CI sanity-check.

## Notes

- `tools/{quantize-tool,compare-backends,t5-bench}/Cargo.toml` are pinned to an older `rev=\"0.9.2-alpha.2\"` and are intentionally left untouched — pre-existing and out of scope for this PR.
- Cargo.lock is gitignored (not bundled with this PR).