### PR TITLE
Fix global centroid cache poisoning across multiple db instances

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -28,6 +28,10 @@ impl DB {
         self.recreated
     }
 
+    pub fn path(&self) -> &PathBuf {
+        &self.db_fn
+    }
+
     fn configure(connection: &Connection) -> SQLResult<()> {
         connection.pragma_update(None, "journal_mode", "WAL")?;
         connection.busy_timeout(std::time::Duration::from_secs(5))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rusqlite::Statement;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::RwLock;
 // Conditionally compile T5 encoder based on features
 #[cfg(feature = "t5-quantized")]
@@ -490,17 +491,18 @@ struct GenerationCentroids {
 
 type CentersCache = Vec<GenerationCentroids>;
 
-static CACHED: Lazy<RwLock<Option<CentersCache>>> = Lazy::new(|| RwLock::new(None));
+static CACHED: Lazy<RwLock<HashMap<PathBuf, CentersCache>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
 
-fn invalidate_center_cache() {
-    *CACHED.write().unwrap() = None;
+fn invalidate_center_cache(db: &DB) {
+    CACHED.write().unwrap().remove(db.path());
 }
 
 fn get_all_generation_centers(db: &DB, device: &Device) -> Result<Vec<GenerationCentroids>> {
     let now = std::time::Instant::now();
     {
         let cache = CACHED.read().unwrap();
-        if let Some(cached) = &*cache {
+        if let Some(cached) = cache.get(db.path()) {
             debug!(
                 "get_all_generation_centers cache hit ({} generations)",
                 cached.len()
@@ -556,7 +558,7 @@ fn get_all_generation_centers(db: &DB, device: &Device) -> Result<Vec<Generation
     );
 
     let mut cache = CACHED.write().unwrap();
-    *cache = Some(all.clone());
+    cache.insert(db.path().clone(), all.clone());
     Ok(all)
 }
 
@@ -1391,7 +1393,7 @@ fn write_buckets_for_range(
 pub fn full_index(db: &DB, device: &Device) -> Result<()> {
     db.execute("DELETE FROM bucket")?;
     db.execute("DELETE FROM generation")?;
-    invalidate_center_cache();
+    invalidate_center_cache(db);
     index_chunks(db, device)
 }
 
@@ -1465,7 +1467,7 @@ pub fn index_chunks(db: &DB, device: &Device) -> Result<()> {
     build_layer(db, device, target_level, min_rowid, max_chunk_rowid)?;
 
     db.commit_transaction()?;
-    invalidate_center_cache();
+    invalidate_center_cache(db);
     db.checkpoint();
     Ok(())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -642,6 +642,54 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: the centroid cache was a single global slot. Searching an
+    /// empty DB first cached an empty generation list, causing a subsequent
+    /// search on a populated DB to skip all indexed embeddings.
+    #[test]
+    fn test_cross_db_cache_isolation() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let assets = PathBuf::from("assets");
+        let device = crate::make_device();
+        let embedder = crate::Embedder::new(&device, &assets)?;
+        let mut cache = crate::EmbeddingsCache::new(4);
+
+        // Populated DB with indexed data
+        let baseline_path = dir.path().join("baseline.sqlite");
+        let mut baseline = DB::new(baseline_path.clone())?;
+        for &body in &FACTS {
+            let uuid = Uuid::new_v5(&Uuid::NAMESPACE_OID, body.as_bytes());
+            baseline.add_doc(&uuid, None, &uuid.to_string(), body, None)?;
+        }
+        crate::embed_chunks(&baseline, &embedder, None)?;
+        crate::index_chunks(&baseline, &device)?;
+
+        // Empty DB (simulates an overlay with 0 generations)
+        let overlay_path = dir.path().join("overlay.sqlite");
+        let mut overlay = DB::new(overlay_path)?;
+
+        // Search the empty DB first — this poisoned the global cache before the fix
+        let overlay_results = crate::search(
+            &overlay, &embedder, &mut cache,
+            "a lake with funny colors", THRESHOLD, 10, false, None,
+        )?;
+        assert!(overlay_results.is_empty());
+
+        // Search the populated DB — must still find indexed results
+        let baseline_results = crate::search(
+            &baseline, &embedder, &mut cache,
+            "a lake with funny colors", THRESHOLD, 10, false, None,
+        )?;
+        assert!(
+            !baseline_results.is_empty(),
+            "baseline search must not be poisoned by prior empty-DB search"
+        );
+
+        baseline.clear();
+        baseline.shutdown();
+        overlay.shutdown();
+        Ok(())
+    }
+
     #[test]
     fn test_empty_body_not_embedded() -> anyhow::Result<()> {
         let dir = tempdir()?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -642,8 +642,7 @@ mod tests {
         Ok(())
     }
 
-    /// Regression: the centroid cache was a single global slot. Searching an
-    /// empty DB first cached an empty generation list, causing a subsequent
+    /// Searching an empty DB first cached an empty generation list, causing a subsequent
     /// search on a populated DB to skip all indexed embeddings.
     #[test]
     fn test_cross_db_cache_isolation() -> anyhow::Result<()> {


### PR DESCRIPTION
The global static centroid cache was a single Option, shared across all DB instances. For the case when we have multiple witchcraft dbs in a single process, this meant that we used the wrong centroids.

Key the cache by DB path so each database gets its own entry.

## Changes

- src/lib.rs: Replace the single-slot Option<CentersCache> with HashMap<PathBuf, CentersCache> keyed by DB file path. Cache lookups, writes, and invalidations
are all per-DB.
- src/db.rs: Add pub fn path() getter on DB to expose db_fn for cache keying.
- src/tests.rs: Regression test that searches an empty DB then a populated DB — confirms the populated DB still returns indexed results.

## Test plan

- cargo test --features t5-quantized — 27/27 passing (1 pre-existing failure in test_embedder_without_assets, unrelated)
- test_cross_db_cache_isolation — regression test for this exact scenario
- Manual: run grimoire search against a multi-layer DB, confirm semantic results return ranked matches from the baseline's indexed embeddings