### PR TITLE
Add Pi support to pickbrain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 target
 warp.node
 warp-cli
-pickbrain
+/pickbrain
 .claude/
 
 # Uncompressed OpenVINO model files (large, not versioned)

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,13 @@ pickbrain: prereqs download
 	ln -sf target/$(TARGET)/release/examples/pickbrain ./pickbrain
 
 pickbrain-install: pickbrain
-	mkdir -p ~/bin ~/.claude/skills/pickbrain ~/.codex/skills/pickbrain
+	mkdir -p ~/bin ~/.claude/skills/pickbrain ~/.codex/skills/pickbrain ~/.pi/agent/skills/pickbrain ~/.pi/agent/extensions/pickbrain
 	ln -f $(realpath pickbrain) ~/bin/pickbrain
-	rm -f ~/.claude/skills/pickbrain/skill.md ~/.codex/skills/pickbrain/skill.md
+	rm -f ~/.claude/skills/pickbrain/skill.md ~/.codex/skills/pickbrain/skill.md ~/.pi/agent/skills/pickbrain/skill.md
 	cp skills/pickbrain/SKILL.md ~/.claude/skills/pickbrain/SKILL.md
 	cp skills/pickbrain-codex/SKILL.md ~/.codex/skills/pickbrain/SKILL.md
+	cp skills/pickbrain-pi/SKILL.md ~/.pi/agent/skills/pickbrain/SKILL.md
+	cp extensions/pickbrain-pi/index.ts ~/.pi/agent/extensions/pickbrain/index.ts
 
 macintel: prereqs
 	RUSTFLAGS='-C target-cpu=haswell' cargo build --release --target x86_64-apple-darwin --features t5-quantized,fbgemm,hybrid-dequant,progress

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ standard with sqlite.
 # Pickbrain: semantic search over your AI coding sessions #
 
 Included as an example is **pickbrain** (screenshot above), a CLI that indexes
-your Claude Code and OpenAI Codex session transcripts, memory files, and
+your Pi, Claude Code, and OpenAI Codex session transcripts, memory files, and
 authored documents into a Witchcraft database for fast semantic search. Ever
 wondered "what was that conversation where I fixed the auth middleware?" —
 pickbrain finds it, and lets you resume the session directly.
@@ -73,14 +73,14 @@ make pickbrain
 
 The source lives in `examples/pickbrain/` and demonstrates how to use
 Witchcraft as a library: document ingestion, embedding, indexing, and hybrid
-search. To install pickbrain as a skill for both Claude Code and Codex:
+search. To install pickbrain as a skill/extension for Pi and as a skill for both Claude Code and Codex:
 
 ```
 make pickbrain-install
 ```
 
-This puts the binary on your `PATH` and installs the skill definitions so
-you can use pickbrain directly from either tool to answer questions requiring
+This puts the binary on your `PATH` and installs the skill/extension definitions so
+you can use pickbrain directly from Pi, Claude Code, or Codex to answer questions requiring
 global knowledge of all your projects:
 
 ![skill](skill.png)

--- a/examples/pickbrain/claude_code.rs
+++ b/examples/pickbrain/claude_code.rs
@@ -668,7 +668,9 @@ pub fn ingest_claude_code(db: &mut DB, skip_session: Option<&str>) -> Result<(us
     let projects_dir = PathBuf::from(&home).join(".claude/projects");
 
     if !projects_dir.is_dir() {
-        println!("no Claude Code projects found at {}", projects_dir.display());
+        if !crate::quiet() {
+            println!("no Claude Code projects found at {}", projects_dir.display());
+        }
         return Ok((0, 0, 0, 0));
     }
 
@@ -715,7 +717,7 @@ pub fn ingest_claude_code(db: &mut DB, skip_session: Option<&str>) -> Result<(us
                 }
             }
             let mtime_ms = file_mtime_ms(jsonl_path).unwrap_or(0);
-            println!("{}", jsonl_path.display());
+            crate::print_ingest_path(&jsonl_path);
             for p in extract_written_paths(jsonl_path) {
                 if p.extension().is_some_and(|ext| ext == "md") && p.is_file() {
                     authored_paths.insert(p);
@@ -744,7 +746,7 @@ pub fn ingest_claude_code(db: &mut DB, skip_session: Option<&str>) -> Result<(us
                 if !watermark::file_newer_than(md_path, wm_ts) {
                     continue;
                 }
-                println!("{}", md_path.display());
+                crate::print_ingest_path(md_path);
                 ingested_paths.insert(md_path.clone());
                 let mtime_ms = file_mtime_ms(md_path).unwrap_or(0);
                 match ingest_memory_file(db, md_path, &project_name, mtime_ms) {
@@ -765,7 +767,7 @@ pub fn ingest_claude_code(db: &mut DB, skip_session: Option<&str>) -> Result<(us
                 continue;
             }
             let mtime_ms = file_mtime_ms(md_path).unwrap_or(0);
-            println!("{}", md_path.display());
+            crate::print_ingest_path(md_path);
             ingested_paths.insert(md_path.clone());
             match ingest_authored_file(db, md_path, &project_name, mtime_ms) {
                 Ok(true) => authored_count += 1,
@@ -786,7 +788,7 @@ pub fn ingest_claude_code(db: &mut DB, skip_session: Option<&str>) -> Result<(us
                 continue;
             }
             let mtime_ms = file_mtime_ms(&config_path).unwrap_or(0);
-            println!("{}", config_path.display());
+            crate::print_ingest_path(&config_path);
             match ingest_authored_file(db, &config_path, &project_name, mtime_ms) {
                 Ok(true) => config_count += 1,
                 Ok(false) => {}

--- a/examples/pickbrain/codex.rs
+++ b/examples/pickbrain/codex.rs
@@ -399,7 +399,7 @@ pub fn ingest_codex(db: &mut DB) -> Result<usize> {
         let mtime_ms = file_mtime_ms(&jsonl_path).unwrap_or(0);
         let sid = session_id_from_filename(&jsonl_path);
         let name = session_names.get(&sid).map(|s| s.as_str());
-        println!("{}", jsonl_path.display());
+        crate::print_ingest_path(&jsonl_path);
         match ingest_session(db, &jsonl_path, mtime_ms, name) {
             Ok(n) => session_count += n,
             Err(e) => {

--- a/examples/pickbrain/main.rs
+++ b/examples/pickbrain/main.rs
@@ -36,6 +36,18 @@ fn pickbrain_dir_overridden() -> bool {
         .unwrap_or(false)
 }
 
+pub(crate) fn quiet() -> bool {
+    env::var("PICKBRAIN_QUIET")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+pub(crate) fn print_ingest_path(path: &std::path::Path) {
+    if !quiet() {
+        println!("{}", path.display());
+    }
+}
+
 pub(crate) fn pickbrain_dir() -> PathBuf {
     if let Ok(dir) = env::var(PICKBRAIN_DIR_ENV) {
         if !dir.trim().is_empty() {
@@ -310,12 +322,16 @@ fn ingest(db_name: &PathBuf, skip_session: Option<&str>, stale_ms: i64, types: &
 
     let total = sessions + memories + authored + configs + codex_sessions + pi_sessions + slack_conversations;
     if total == 0 {
-        eprintln!("No new sessions to ingest.");
+        if !quiet() {
+            eprintln!("No new sessions to ingest.");
+        }
         return Ok(false);
     }
-    eprintln!(
-        "ingested {sessions} claude sessions, {codex_sessions} codex sessions, {pi_sessions} pi sessions, {slack_conversations} slack conversations, {memories} memory files, {authored} authored files, {configs} config files"
-    );
+    if !quiet() {
+        eprintln!(
+            "ingested {sessions} claude sessions, {codex_sessions} codex sessions, {pi_sessions} pi sessions, {slack_conversations} slack conversations, {memories} memory files, {authored} authored files, {configs} config files"
+        );
+    }
     Ok(true)
 }
 
@@ -1999,6 +2015,7 @@ fn main() -> Result<()> {
                 eprintln!("  --session ID         search within a session, channel, or thread");
                 eprintln!("  --since 24h|7d|2w    only search recent history");
                 eprintln!("  --type claude,codex,pi,slack  filter by source");
+                eprintln!("  --quiet              suppress ingest progress output");
                 eprintln!("  -n N                 number of results (0=unlimited, default: unlimited in TUI, 20 in pipe)");
                 eprintln!("  --dm                 only DMs (Slack)");
                 eprintln!("  --no-dm              exclude DMs (Slack)");
@@ -2009,6 +2026,9 @@ fn main() -> Result<()> {
                 eprintln!("Environment:");
                 eprintln!("  PICKBRAIN_DIR        override the pickbrain DB and state directory");
                 std::process::exit(0);
+            }
+            "--quiet" => {
+                std::env::set_var("PICKBRAIN_QUIET", "1");
             }
             "--nuke" => {
                 let db_name = db_path();

--- a/examples/pickbrain/main.rs
+++ b/examples/pickbrain/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 mod claude_code;
 mod codex;
+mod pi;
 mod slack;
 mod watermark;
 
@@ -180,6 +181,13 @@ fn needs_ingest(
         return Ok(true);
     }
 
+    if wants_source(types, "pi") {
+        let pi_skip = skip_session.filter(|_| watermark::is_fresh(&watermark::pi_path(), stale_ms));
+        if pi::has_work(pi_skip) {
+            return Ok(true);
+        }
+    }
+
     if wants_source(types, "slack") && slack::has_work() {
         return Ok(true);
     }
@@ -194,11 +202,29 @@ fn warn_lookup_only(reason: impl std::fmt::Display) {
 fn reset_ingest_watermarks() {
     watermark::remove(&watermark::claude_path());
     watermark::remove(&watermark::codex_path());
+    watermark::remove(&watermark::pi_path());
     slack::remove_watermark();
 }
 
 /// Walk up the process tree to find the calling Claude Code session ID.
 fn detect_active_session() -> Option<String> {
+    for key in ["PICKBRAIN_ACTIVE_SESSION_ID", "PI_SESSION_ID"] {
+        if let Ok(value) = env::var(key) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    for key in ["PICKBRAIN_ACTIVE_SESSION_FILE", "PI_SESSION_FILE"] {
+        if let Ok(value) = env::var(key) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(pi::session_id_from_filename(std::path::Path::new(value)));
+            }
+        }
+    }
+
     let home = env::var("HOME").ok()?;
     let sessions_dir = PathBuf::from(&home).join(".claude/sessions");
     let mut pid = std::process::id() as i32;
@@ -269,19 +295,26 @@ fn ingest(db_name: &PathBuf, skip_session: Option<&str>, stale_ms: i64, types: &
         0
     };
 
+    let pi_sessions = if want("pi") {
+        let pi_skip = skip_session.filter(|_| watermark::is_fresh(&watermark::pi_path(), stale_ms));
+        pi::ingest_pi(&mut db, pi_skip)?
+    } else {
+        0
+    };
+
     let slack_conversations = if want("slack") {
         slack::ingest_slack(&mut db)?
     } else {
         0
     };
 
-    let total = sessions + memories + authored + configs + codex_sessions + slack_conversations;
+    let total = sessions + memories + authored + configs + codex_sessions + pi_sessions + slack_conversations;
     if total == 0 {
         eprintln!("No new sessions to ingest.");
         return Ok(false);
     }
     eprintln!(
-        "ingested {sessions} claude sessions, {codex_sessions} codex sessions, {slack_conversations} slack conversations, {memories} memory files, {authored} authored files, {configs} config files"
+        "ingested {sessions} claude sessions, {codex_sessions} codex sessions, {pi_sessions} pi sessions, {slack_conversations} slack conversations, {memories} memory files, {authored} authored files, {configs} config files"
     );
     Ok(true)
 }
@@ -337,6 +370,26 @@ fn read_jsonl_line(path: &str, offset: u64, len: u64) -> Option<String> {
     String::from_utf8(buf).ok()
 }
 
+fn extract_pi_content_text(content: &serde_json::Value) -> Option<String> {
+    if content.is_string() {
+        return content.as_str().map(|s| s.to_string());
+    }
+    let blocks = content.as_array()?;
+    let texts: Vec<&str> = blocks
+        .iter()
+        .filter_map(|b| match b.get("type").and_then(|t| t.as_str()) {
+            Some("text") => b.get("text").and_then(|t| t.as_str()),
+            Some("thinking") => b.get("thinking").and_then(|t| t.as_str()),
+            _ => None,
+        })
+        .collect();
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join("\n"))
+    }
+}
+
 fn read_turn_at(path: &str, source: &str, tm: &TurnMeta) -> Option<SessionTurn> {
     let line = read_jsonl_line(path, tm.byte_offset, tm.byte_len)?;
     let v: serde_json::Value = serde_json::from_str(&line).ok()?;
@@ -362,6 +415,13 @@ fn read_turn_at(path: &str, source: &str, tm: &TurnMeta) -> Option<SessionTurn> 
         } else {
             return None;
         }
+    } else if source == "pi" {
+        let content = if v.get("type").and_then(|t| t.as_str()) == Some("custom_message") {
+            v.get("content")?
+        } else {
+            v.get("message")?.get("content")?
+        };
+        extract_pi_content_text(content)?
     } else {
         // Claude Code
         let msg = v.get("message")?;
@@ -956,13 +1016,13 @@ fn search_tui(
                             }
                             let match_role = matched_tm.map(|tm| tm.role.as_str()).unwrap_or("");
                             let role_prefix = if r.source == "slack" {
-                                ""
+                                String::new()
                             } else if match_role == "user" {
-                                "[User] "
+                                "[User] ".to_string()
                             } else if match_role == "assistant" {
-                                if r.source == "codex" { "[Codex] " } else { "[Claude] " }
+                                format!("{} ", role_label(&r.source))
                             } else {
-                                ""
+                                String::new()
                             };
                             ratatui::widgets::ListItem::new(vec![
                                 Line::from(meta_spans),
@@ -1045,19 +1105,15 @@ fn search_tui(
                                     .fg(Color::Cyan)
                                     .add_modifier(Modifier::BOLD)
                             };
+                            let role_prefix = if r.source == "slack" {
+                                String::new()
+                            } else if turn.role == "user" {
+                                "[User] ".to_string()
+                            } else {
+                                format!("{} ", role_label(&r.source))
+                            };
                             lines.push(Line::from(vec![
-                                Span::styled(
-                                    if r.source == "slack" {
-                                        ""
-                                    } else if turn.role == "user" {
-                                        "[User] "
-                                    } else if r.source == "codex" {
-                                        "[Codex] "
-                                    } else {
-                                        "[Claude] "
-                                    },
-                                    role_style,
-                                ),
+                                Span::styled(role_prefix, role_style),
                                 Span::styled(
                                     format_date(&turn.timestamp),
                                     Style::default().fg(Color::DarkGray),
@@ -1299,6 +1355,13 @@ fn read_cwd_from_jsonl(path: &str, source: &str) -> Option<String> {
                     return Some(cwd.to_string());
                 }
             }
+        } else if source == "pi" {
+            // Pi: cwd is in the session header
+            if v.get("type").and_then(|t| t.as_str()) == Some("session") {
+                if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
+                    return Some(cwd.to_string());
+                }
+            }
         } else {
             // Claude: cwd is a top-level field
             if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
@@ -1366,6 +1429,12 @@ fn launch_resume(s: &BranchSession, checkout_branch: bool) -> Result<()> {
             .args(["resume", session_id])
             .exec();
         Err(err.into())
+    } else if s.source == "pi" {
+        eprintln!("Resuming pi session {session_id}...");
+        let err = std::process::Command::new("pi")
+            .args(["--session", session_id])
+            .exec();
+        Err(err.into())
     } else {
         eprintln!("Resuming claude session {session_id}...");
         let err = std::process::Command::new("claude")
@@ -1388,10 +1457,28 @@ fn slack_conv_tag(conv_key: &str) -> String {
     String::new()
 }
 
+fn source_label(source: &str) -> &str {
+    match source {
+        "slack" => "slack",
+        "codex" => "codex",
+        "pi" => "pi",
+        _ => "claude",
+    }
+}
+
+fn role_label(source: &str) -> &str {
+    match source {
+        "codex" => "[Codex]",
+        "pi" => "[Pi]",
+        _ => "[Claude]",
+    }
+}
+
 fn strip_body_prefix(s: &str) -> &str {
     s.strip_prefix("[User] ")
         .or_else(|| s.strip_prefix("[Claude] "))
         .or_else(|| s.strip_prefix("[Codex] "))
+        .or_else(|| s.strip_prefix("[Pi] "))
         .unwrap_or(s)
 }
 
@@ -1447,7 +1534,7 @@ fn search_plain(
             .filter(|tm| !tm.timestamp.is_empty())
             .map(|tm| format_date(&tm.timestamp))
             .unwrap_or_else(|| r.timestamp.clone());
-        let source_label = if r.source == "slack" { "slack" } else if r.source == "codex" { "codex" } else { "claude" };
+        let source_label = source_label(&r.source);
         let filename = if r.path.ends_with(".md") {
             format!("  {}", r.path)
         } else {
@@ -1492,10 +1579,8 @@ fn search_plain(
                 let tm = &r.turns[i];
                 let label = if tm.role == "user" {
                     "[User]"
-                } else if r.source == "codex" {
-                    "[Codex]"
                 } else {
-                    "[Claude]"
+                    role_label(&r.source)
                 };
                 let prefix = if i == mi { ">>>" } else { "  " };
                 writeln!(buf, "{prefix} {label} {}", format_date(&tm.timestamp))?;
@@ -1539,7 +1624,7 @@ fn session_meta_spans(
             Style::default().fg(Color::Magenta),
         ));
     } else if !session_id.is_empty() {
-        let source_label = if source == "codex" { "codex" } else { "claude" };
+        let source_label = source_label(source);
         let short_sid = if session_id.len() > 8 { &session_id[..8] } else { session_id };
         spans.push(Span::styled(
             format!("  {source_label} {short_sid}"),
@@ -1852,6 +1937,7 @@ fn dump(db_name: &PathBuf, session_id: &str, turns_range: Option<&str>, since_ms
                 && !l.starts_with("[User]")
                 && !l.starts_with("[Claude]")
                 && !l.starts_with("[Codex]")
+                && !l.starts_with("[Pi]")
         }) {
             writeln!(buf, "{line}")?;
         }
@@ -1912,7 +1998,7 @@ fn main() -> Result<()> {
                 eprintln!("  --exclude-current    exclude the calling session");
                 eprintln!("  --session ID         search within a session, channel, or thread");
                 eprintln!("  --since 24h|7d|2w    only search recent history");
-                eprintln!("  --type claude,slack  filter by source (claude, codex, slack)");
+                eprintln!("  --type claude,codex,pi,slack  filter by source");
                 eprintln!("  -n N                 number of results (0=unlimited, default: unlimited in TUI, 20 in pipe)");
                 eprintln!("  --dm                 only DMs (Slack)");
                 eprintln!("  --no-dm              exclude DMs (Slack)");
@@ -1934,6 +2020,7 @@ fn main() -> Result<()> {
                 }
                 watermark::remove(&watermark::claude_path());
                 watermark::remove(&watermark::codex_path());
+                watermark::remove(&watermark::pi_path());
                 slack::remove_watermark();
                 std::process::exit(0);
             }

--- a/examples/pickbrain/pi.rs
+++ b/examples/pickbrain/pi.rs
@@ -424,7 +424,7 @@ pub fn ingest_pi(db: &mut DB, skip_session: Option<&str>) -> Result<usize> {
             continue;
         }
         let mtime_ms = file_mtime_ms(&jsonl_path).unwrap_or(0);
-        println!("{}", jsonl_path.display());
+        crate::print_ingest_path(&jsonl_path);
         match ingest_session(db, &jsonl_path, mtime_ms) {
             Ok(n) => session_count += n,
             Err(e) => {

--- a/examples/pickbrain/pi.rs
+++ b/examples/pickbrain/pi.rs
@@ -1,0 +1,492 @@
+use anyhow::Result;
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+use witchcraft::DB;
+
+const MIN_CHUNK_CODEPOINTS: usize = 5;
+const MAX_CHUNK_CODEPOINTS: usize = 4000;
+
+// Stable UUID namespace for Pi sessions.
+const PI_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x70, 0x69, 0x63, 0x6b, 0x62, 0x72, 0x61, 0x69, 0x6e, 0x2d, 0x70, 0x69, 0x2d, 0x76, 0x31, 0x00,
+]);
+
+#[derive(Deserialize)]
+struct Entry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    timestamp: Option<String>,
+    id: Option<String>,
+    cwd: Option<String>,
+    message: Option<Message>,
+    name: Option<String>,
+    content: Option<Content>,
+}
+
+#[derive(Deserialize)]
+struct Message {
+    role: Option<String>,
+    content: Option<Content>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Content {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
+#[derive(Deserialize)]
+struct ContentBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    thinking: Option<String>,
+}
+
+struct Chunk {
+    role: String,
+    text: String,
+    timestamp: String,
+    ts_ms: i64,
+    byte_offset: u64,
+    byte_len: u64,
+}
+
+struct SessionMeta {
+    id: Option<String>,
+    cwd: Option<String>,
+    name: Option<String>,
+}
+
+fn codepoint_len(s: &str) -> usize {
+    s.chars().count()
+}
+
+fn extract_text(content: &Content) -> Option<String> {
+    match content {
+        Content::Text(s) => Some(s.clone()),
+        Content::Blocks(blocks) => {
+            let texts: Vec<&str> = blocks
+                .iter()
+                .filter_map(|b| match b.block_type.as_str() {
+                    "text" => b.text.as_deref(),
+                    "thinking" => b.thinking.as_deref(),
+                    _ => None,
+                })
+                .collect();
+            if texts.is_empty() {
+                None
+            } else {
+                Some(texts.join("\n"))
+            }
+        }
+    }
+}
+
+fn sanitize(text: &str) -> String {
+    let s = strip_code(text);
+    let s = strip_tool_signatures(&s);
+    compact(&s)
+}
+
+fn strip_code(text: &str) -> String {
+    let re = Regex::new(r"```[\s\S]*?```").unwrap();
+    let s = re.replace_all(text, " ").to_string();
+    let re = Regex::new(r"```[\s\S]*$").unwrap();
+    let s = re.replace_all(&s, " ").to_string();
+    let re = Regex::new(r"`[^`]*`").unwrap();
+    re.replace_all(&s, " ").to_string()
+}
+
+fn strip_tool_signatures(text: &str) -> String {
+    // Pi stores provider-specific signatures beside assistant text/thinking in sibling
+    // fields, not in the text itself. This catches pasted/exported variants if present.
+    let re = Regex::new(r#"\{\"v\":\d+,\"id\":\"[^\"]+\"[\s\S]*?\}"#).unwrap();
+    re.replace_all(text, " ").to_string()
+}
+
+fn compact(text: &str) -> String {
+    let re = Regex::new(r"\s{2,}").unwrap();
+    re.replace_all(text, " ").trim().to_string()
+}
+
+fn parse_session_file(path: &Path) -> (SessionMeta, Vec<Chunk>) {
+    let raw = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => {
+            return (
+                SessionMeta {
+                    id: None,
+                    cwd: None,
+                    name: None,
+                },
+                vec![],
+            );
+        }
+    };
+
+    let mut meta = SessionMeta {
+        id: None,
+        cwd: None,
+        name: None,
+    };
+    let mut chunks = Vec::new();
+    let mut offset: u64 = 0;
+
+    for line in raw.lines() {
+        let line_offset = offset;
+        offset += line.len() as u64 + 1; // +1 for newline
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let entry: Entry = match serde_json::from_str(line) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        match entry.entry_type.as_str() {
+            "session" => {
+                if meta.id.is_none() {
+                    meta.id = entry.id;
+                }
+                if meta.cwd.is_none() {
+                    meta.cwd = entry.cwd;
+                }
+                continue;
+            }
+            "session_info" => {
+                if let Some(name) = entry.name {
+                    meta.name = Some(name);
+                }
+                continue;
+            }
+            "custom_message" => {
+                let raw_text = match entry.content.as_ref().and_then(extract_text) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                push_chunk(
+                    &mut chunks,
+                    "assistant".to_string(),
+                    raw_text,
+                    entry.timestamp,
+                    line_offset,
+                    line.len() as u64,
+                );
+            }
+            "message" => {
+                let msg = match entry.message {
+                    Some(m) => m,
+                    None => continue,
+                };
+                let role = match msg.role.as_deref() {
+                    Some("user") => "user".to_string(),
+                    Some("assistant") => "assistant".to_string(),
+                    _ => continue,
+                };
+                let raw_text = match msg.content.as_ref().and_then(extract_text) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                push_chunk(
+                    &mut chunks,
+                    role,
+                    raw_text,
+                    entry.timestamp,
+                    line_offset,
+                    line.len() as u64,
+                );
+            }
+            _ => continue,
+        }
+    }
+
+    chunks.sort_by_key(|c| c.ts_ms);
+    (meta, chunks)
+}
+
+fn push_chunk(
+    chunks: &mut Vec<Chunk>,
+    role: String,
+    raw_text: String,
+    timestamp: Option<String>,
+    byte_offset: u64,
+    byte_len: u64,
+) {
+    let text = sanitize(&raw_text);
+    if text.is_empty() {
+        return;
+    }
+    let cp_len = codepoint_len(&text);
+    if !(MIN_CHUNK_CODEPOINTS..=MAX_CHUNK_CODEPOINTS).contains(&cp_len) {
+        return;
+    }
+
+    let timestamp = match timestamp {
+        Some(ts) if !ts.is_empty() => ts,
+        _ => return,
+    };
+    let ts_ms = chrono::DateTime::parse_from_rfc3339(&timestamp)
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or(0);
+    if ts_ms <= 0 {
+        return;
+    }
+
+    chunks.push(Chunk {
+        role,
+        text,
+        timestamp,
+        ts_ms,
+        byte_offset,
+        byte_len,
+    });
+}
+
+fn project_from_cwd(cwd: &str) -> String {
+    Path::new(cwd)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| cwd.to_string())
+}
+
+pub fn session_id_from_filename(path: &Path) -> String {
+    let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+    // Filename: <timestamp>_<UUID>
+    if let Some((_, id)) = stem.rsplit_once('_') {
+        if id.chars().filter(|&c| c == '-').count() == 4 {
+            return id.to_string();
+        }
+    }
+    stem.to_string()
+}
+
+fn ingest_session(db: &mut DB, path: &Path, mtime_ms: i64) -> Result<usize> {
+    let (meta, chunks) = parse_session_file(path);
+    if chunks.is_empty() {
+        return Ok(0);
+    }
+
+    let project_name = meta
+        .cwd
+        .as_deref()
+        .map(project_from_cwd)
+        .unwrap_or_default();
+    let session_id = meta.id.unwrap_or_else(|| session_id_from_filename(path));
+    let session_title = meta.name.unwrap_or_else(|| {
+        chunks
+            .iter()
+            .find(|c| c.role == "user")
+            .map(|c| c.text.chars().take(240).collect())
+            .unwrap_or_default()
+    });
+
+    // Split into interactions starting at each user message.
+    let mut interactions: Vec<&[Chunk]> = Vec::new();
+    let mut start = 0;
+    for (i, chunk) in chunks.iter().enumerate() {
+        if chunk.role == "user" && i > start {
+            interactions.push(&chunks[start..i]);
+            start = i;
+        }
+    }
+    interactions.push(&chunks[start..]);
+
+    let mut count = 0;
+    for (turn_idx, interaction) in interactions.iter().enumerate() {
+        let header = format!("[pi:{project_name}] {session_title}\n");
+        let mut all_parts = vec![header];
+        let mut turns_meta: Vec<serde_json::Value> = Vec::new();
+
+        for chunk in *interaction {
+            let label = if chunk.role == "user" {
+                "[User]"
+            } else {
+                "[Pi]"
+            };
+            all_parts.push(format!("{label} {}\n", chunk.text));
+            turns_meta.push(serde_json::json!({
+                "role": chunk.role,
+                "timestamp": chunk.timestamp,
+                "off": chunk.byte_offset,
+                "len": chunk.byte_len,
+            }));
+        }
+
+        let lengths: Vec<usize> = all_parts.iter().map(|p| p.chars().count()).collect();
+        let body = all_parts.join("");
+        if body.trim().is_empty() {
+            continue;
+        }
+
+        let uuid = Uuid::new_v5(&PI_NAMESPACE, format!("{session_id}:{turn_idx}").as_bytes());
+        let metadata = serde_json::json!({
+            "source": "pi",
+            "project": project_name,
+            "session_id": session_id,
+            "session_name": session_title,
+            "turn": turn_idx,
+            "path": path.to_string_lossy(),
+            "cwd": meta.cwd,
+            "mtime_ms": mtime_ms,
+            "turns": turns_meta,
+            "branch": null,
+        })
+        .to_string();
+
+        let date = iso8601_timestamp::Timestamp::parse(&interaction[0].timestamp);
+        db.add_doc(&uuid, date, &metadata, &body, Some(lengths))?;
+        count += 1;
+    }
+
+    Ok(count)
+}
+
+fn file_mtime_ms(path: &Path) -> Option<i64> {
+    fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as i64)
+}
+
+use crate::watermark;
+
+fn sessions_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home).join(".pi/agent/sessions")
+}
+
+fn collect_session_files(base: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let entries = match fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|ext| ext == "jsonl") {
+                out.push(p);
+            }
+        }
+    }
+    walk(base, &mut files);
+    files.sort();
+    files
+}
+
+fn matches_skip(path: &Path, skip_session: Option<&str>) -> bool {
+    let Some(skip) = skip_session else {
+        return false;
+    };
+    if skip.is_empty() {
+        return false;
+    }
+    if path.to_string_lossy() == skip {
+        return true;
+    }
+    session_id_from_filename(path) == skip
+}
+
+pub fn ingest_pi(db: &mut DB, skip_session: Option<&str>) -> Result<usize> {
+    let dir = sessions_dir();
+    if !dir.is_dir() {
+        return Ok(0);
+    }
+
+    let wm_path = watermark::pi_path();
+    let wm_ts = watermark::mtime_ms(&wm_path);
+    let mut session_count = 0usize;
+    let mut seen = HashSet::new();
+
+    for jsonl_path in collect_session_files(&dir) {
+        if !watermark::file_newer_than(&jsonl_path, wm_ts) {
+            continue;
+        }
+        if matches_skip(&jsonl_path, skip_session) {
+            continue;
+        }
+        if !seen.insert(jsonl_path.clone()) {
+            continue;
+        }
+        let mtime_ms = file_mtime_ms(&jsonl_path).unwrap_or(0);
+        println!("{}", jsonl_path.display());
+        match ingest_session(db, &jsonl_path, mtime_ms) {
+            Ok(n) => session_count += n,
+            Err(e) => {
+                log::warn!("failed to ingest pi {}: {e}", jsonl_path.display());
+            }
+        }
+    }
+
+    watermark::touch(&wm_path);
+    Ok(session_count)
+}
+
+pub fn has_work(skip_session: Option<&str>) -> bool {
+    let dir = sessions_dir();
+    if !dir.is_dir() {
+        return false;
+    }
+
+    let wm_ts = watermark::mtime_ms(&watermark::pi_path());
+    collect_session_files(&dir)
+        .iter()
+        .any(|path| !matches_skip(path, skip_session) && watermark::file_newer_than(path, wm_ts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tempfile(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_parse_pi_session() {
+        let content = format!(
+            "{}\n{}\n{}\n{}\n",
+            r#"{"type":"session","version":3,"id":"abc","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/Users/me/project"}"#,
+            r#"{"type":"session_info","id":"n","parentId":null,"timestamp":"2026-01-01T00:00:00.000Z","name":"Named Session"}"#,
+            r#"{"type":"message","id":"u","parentId":null,"timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"hello from user"}]}}"#,
+            r#"{"type":"message","id":"a","parentId":"u","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"thinking about it"},{"type":"text","text":"hello back"}]}}"#,
+        );
+        let f = write_tempfile(&content);
+        let (meta, chunks) = parse_session_file(f.path());
+        assert_eq!(meta.id.as_deref(), Some("abc"));
+        assert_eq!(meta.cwd.as_deref(), Some("/Users/me/project"));
+        assert_eq!(meta.name.as_deref(), Some("Named Session"));
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].role, "user");
+        assert!(chunks[1].text.contains("hello back"));
+    }
+
+    #[test]
+    fn test_session_id_from_filename() {
+        let p =
+            PathBuf::from("2026-06-03T12-19-44-826Z_019e8d6c-e63a-7e52-8290-f77811e9fdac.jsonl");
+        assert_eq!(
+            session_id_from_filename(&p),
+            "019e8d6c-e63a-7e52-8290-f77811e9fdac"
+        );
+    }
+}

--- a/examples/pickbrain/watermark.rs
+++ b/examples/pickbrain/watermark.rs
@@ -8,7 +8,9 @@ fn watermark_path(agent_dir: &str) -> PathBuf {
         return crate::pickbrain_dir().join(format!("{name}.watermark"));
     }
     let home = std::env::var("HOME").unwrap_or_default();
-    PathBuf::from(home).join(agent_dir).join("pickbrain.watermark")
+    PathBuf::from(home)
+        .join(agent_dir)
+        .join("pickbrain.watermark")
 }
 
 pub fn claude_path() -> PathBuf {
@@ -17,6 +19,10 @@ pub fn claude_path() -> PathBuf {
 
 pub fn codex_path() -> PathBuf {
     watermark_path(".codex")
+}
+
+pub fn pi_path() -> PathBuf {
+    watermark_path(".pi/agent")
 }
 
 pub fn mtime_ms(path: &Path) -> i64 {

--- a/extensions/pickbrain-pi/index.ts
+++ b/extensions/pickbrain-pi/index.ts
@@ -1,0 +1,162 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const MAX_OUTPUT_BYTES = 50 * 1024;
+
+type RunResult = {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+	truncated: boolean;
+};
+
+function truncateOutput(text: string): { text: string; truncated: boolean } {
+	const bytes = Buffer.byteLength(text, "utf8");
+	if (bytes <= MAX_OUTPUT_BYTES) return { text, truncated: false };
+	let end = MAX_OUTPUT_BYTES;
+	while (end > 0 && (Buffer.from(text.slice(0, end)).at(-1) ?? 0) >= 0x80) end--;
+	return {
+		text: text.slice(0, end) + `\n\n[Output truncated to ${MAX_OUTPUT_BYTES} bytes]`,
+		truncated: true,
+	};
+}
+
+function pickbrainCommand(): string {
+	if (process.env.PICKBRAIN_BIN) return process.env.PICKBRAIN_BIN;
+	const homeBin = join(homedir(), "bin", "pickbrain");
+	try {
+		accessSync(homeBin, constants.X_OK);
+		return homeBin;
+	} catch {
+		return "pickbrain";
+	}
+}
+
+function runPickbrain(
+	args: string[],
+	cwd: string,
+	env: Record<string, string>,
+	signal?: AbortSignal,
+): Promise<RunResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(pickbrainCommand(), args, {
+			cwd,
+			env: { ...process.env, ...env },
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		const timeout = setTimeout(() => {
+			child.kill("SIGTERM");
+		}, 120_000);
+		const abort = () => child.kill("SIGTERM");
+		signal?.addEventListener("abort", abort, { once: true });
+
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.on("error", (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abort);
+			reject(error);
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			signal?.removeEventListener("abort", abort);
+			const out = truncateOutput(stdout);
+			const err = truncateOutput(stderr);
+			resolve({ stdout: out.text, stderr: err.text, code, truncated: out.truncated || err.truncated });
+		});
+	});
+}
+
+function sessionEnv(ctx: any): Record<string, string> {
+	const env: Record<string, string> = {};
+	const sessionId = ctx.sessionManager?.getSessionId?.();
+	const sessionFile = ctx.sessionManager?.getSessionFile?.();
+	if (sessionId) env.PICKBRAIN_ACTIVE_SESSION_ID = String(sessionId);
+	if (sessionFile) env.PICKBRAIN_ACTIVE_SESSION_FILE = String(sessionFile);
+	return env;
+}
+
+function renderResult(result: RunResult): string {
+	const parts: string[] = [];
+	if (result.stderr.trim()) parts.push(result.stderr.trimEnd());
+	if (result.stdout.trim()) parts.push(result.stdout.trimEnd());
+	if (result.code && result.code !== 0) parts.push(`[pickbrain exited with code ${result.code}]`);
+	return parts.join("\n").trim() || "pickbrain returned no output";
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "pickbrain_search",
+		label: "Pickbrain",
+		description:
+			"Semantic search over past Pi, Claude Code, Codex, and Slack conversations. Use for recalling previous coding-agent sessions, dumping sessions, or searching history.",
+		promptSnippet: "Search previous Pi/Claude/Codex/Slack conversations with pickbrain semantic search",
+		promptGuidelines: [
+			"Use pickbrain_search when the user asks to recall, find, or reference a previous Pi, Claude Code, Codex, or Slack conversation.",
+		],
+		parameters: Type.Object({
+			query: Type.Optional(Type.String({ description: "Search query. May be omitted with filters to browse recent matches." })),
+			current: Type.Optional(Type.Boolean({ description: "Search only the current Pi session." })),
+			excludeCurrent: Type.Optional(Type.Boolean({ description: "Exclude the current Pi session." })),
+			session: Type.Optional(Type.String({ description: "Session id, Slack channel, or thr:<timestamp> to search within." })),
+			type: Type.Optional(Type.String({ description: "Source filter, e.g. pi, claude, codex, slack, or comma-separated." })),
+			since: Type.Optional(Type.String({ description: "Recent-history filter like 24h, 7d, or 2w." })),
+			branch: Type.Optional(Type.String({ description: "Git branch filter. Use . for the current branch." })),
+			numResults: Type.Optional(Type.Number({ description: "Number of results. 0 means unlimited." })),
+			dump: Type.Optional(Type.String({ description: "Dump this session/channel/thread id instead of searching." })),
+			turns: Type.Optional(Type.String({ description: "Turn range for dumps, e.g. 2-5." })),
+		}),
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const args: string[] = [];
+			if (params.current) args.push("--current");
+			if (params.excludeCurrent) args.push("--exclude-current");
+			if (params.session) args.push("--session", params.session);
+			if (params.type) args.push("--type", params.type);
+			if (params.since) args.push("--since", params.since);
+			if (params.branch) args.push("--branch", params.branch);
+			if (typeof params.numResults === "number") args.push("-n", String(params.numResults));
+			if (params.dump) args.push("--dump", params.dump);
+			if (params.turns) args.push("--turns", params.turns);
+			if (params.query) args.push(params.query);
+
+			const result = await runPickbrain(args, ctx.cwd, sessionEnv(ctx), signal);
+			const text = renderResult(result);
+			return {
+				content: [{ type: "text", text }],
+				details: { args, code: result.code, truncated: result.truncated },
+			};
+		},
+	});
+
+	pi.registerCommand("pickbrain", {
+		description: "Run pickbrain with the current Pi session in the environment",
+		handler: async (args, ctx) => {
+			const argv = args.trim() ? args.trim().split(/\s+/) : [];
+			const result = await runPickbrain(argv, ctx.cwd, sessionEnv(ctx), ctx.signal);
+			pi.sendMessage(
+				{
+					customType: "pickbrain",
+					content: renderResult(result),
+					display: true,
+					details: { args: argv, code: result.code, truncated: result.truncated },
+				},
+				{ triggerTurn: false },
+			);
+		},
+	});
+}

--- a/extensions/pickbrain-pi/index.ts
+++ b/extensions/pickbrain-pi/index.ts
@@ -6,12 +6,27 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 const MAX_OUTPUT_BYTES = 50 * 1024;
+const DEFAULT_RESULTS = 5;
 
 type RunResult = {
 	stdout: string;
 	stderr: string;
 	code: number | null;
 	truncated: boolean;
+};
+
+type PickbrainParams = {
+	query?: string;
+	current?: boolean;
+	excludeCurrent?: boolean;
+	session?: string;
+	type?: string;
+	since?: string;
+	branch?: string;
+	numResults?: number;
+	dump?: string;
+	turns?: string;
+	allSources?: boolean;
 };
 
 function truncateOutput(text: string): { text: string; truncated: boolean } {
@@ -45,7 +60,7 @@ function runPickbrain(
 	return new Promise((resolve, reject) => {
 		const child = spawn(pickbrainCommand(), args, {
 			cwd,
-			env: { ...process.env, ...env },
+			env: { ...process.env, PICKBRAIN_QUIET: "1", ...env },
 		});
 
 		let stdout = "";
@@ -99,41 +114,64 @@ function renderResult(result: RunResult): string {
 	return parts.join("\n").trim() || "pickbrain returned no output";
 }
 
+function addDefaultScope(args: string[], params: PickbrainParams) {
+	if (params.dump || params.allSources) return;
+	if (params.type) {
+		if (params.type !== "all") args.push("--type", params.type);
+		return;
+	}
+	args.push("--type", "pi");
+}
+
+function buildArgs(params: PickbrainParams): string[] {
+	const args: string[] = ["--quiet"];
+	if (params.current) args.push("--current");
+	if (params.excludeCurrent) args.push("--exclude-current");
+	if (params.session) args.push("--session", params.session);
+	if (params.since) args.push("--since", params.since);
+	if (params.branch) args.push("--branch", params.branch);
+	if (typeof params.numResults === "number") args.push("-n", String(params.numResults));
+	else if (!params.dump) args.push("-n", String(DEFAULT_RESULTS));
+	if (params.dump) args.push("--dump", params.dump);
+	if (params.turns) args.push("--turns", params.turns);
+	addDefaultScope(args, params);
+	if (params.query) args.push(params.query);
+	return args;
+}
+
+function parseSlashArgs(raw: string): string[] {
+	const text = raw.trim();
+	if (!text) return ["--quiet", "--type", "pi", "-n", String(DEFAULT_RESULTS)];
+	if (text.startsWith("-")) return ["--quiet", ...text.split(/\s+/)];
+	return ["--quiet", "--type", "pi", "-n", String(DEFAULT_RESULTS), text];
+}
+
 export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "pickbrain_search",
 		label: "Pickbrain",
 		description:
-			"Semantic search over past Pi, Claude Code, Codex, and Slack conversations. Use for recalling previous coding-agent sessions, dumping sessions, or searching history.",
-		promptSnippet: "Search previous Pi/Claude/Codex/Slack conversations with pickbrain semantic search",
+			"Semantic search over past Pi, Claude Code, Codex, and Slack conversations. Defaults to Pi sessions; set type or allSources for broader search.",
+		promptSnippet: "Search previous Pi coding sessions with pickbrain semantic search",
 		promptGuidelines: [
-			"Use pickbrain_search when the user asks to recall, find, or reference a previous Pi, Claude Code, Codex, or Slack conversation.",
+			"Use pickbrain_search when the user asks to recall, find, or reference a previous Pi coding session.",
+			"pickbrain_search defaults to Pi sessions. Set type to claude, codex, slack, or a comma-separated list only when the user asks to search outside Pi.",
 		],
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Search query. May be omitted with filters to browse recent matches." })),
 			current: Type.Optional(Type.Boolean({ description: "Search only the current Pi session." })),
 			excludeCurrent: Type.Optional(Type.Boolean({ description: "Exclude the current Pi session." })),
 			session: Type.Optional(Type.String({ description: "Session id, Slack channel, or thr:<timestamp> to search within." })),
-			type: Type.Optional(Type.String({ description: "Source filter, e.g. pi, claude, codex, slack, or comma-separated." })),
+			type: Type.Optional(Type.String({ description: "Source filter, e.g. pi, claude, codex, slack, all, or comma-separated." })),
+			allSources: Type.Optional(Type.Boolean({ description: "Search all sources instead of defaulting to Pi sessions." })),
 			since: Type.Optional(Type.String({ description: "Recent-history filter like 24h, 7d, or 2w." })),
 			branch: Type.Optional(Type.String({ description: "Git branch filter. Use . for the current branch." })),
-			numResults: Type.Optional(Type.Number({ description: "Number of results. 0 means unlimited." })),
+			numResults: Type.Optional(Type.Number({ description: `Number of results. Defaults to ${DEFAULT_RESULTS}; 0 means unlimited.` })),
 			dump: Type.Optional(Type.String({ description: "Dump this session/channel/thread id instead of searching." })),
 			turns: Type.Optional(Type.String({ description: "Turn range for dumps, e.g. 2-5." })),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-			const args: string[] = [];
-			if (params.current) args.push("--current");
-			if (params.excludeCurrent) args.push("--exclude-current");
-			if (params.session) args.push("--session", params.session);
-			if (params.type) args.push("--type", params.type);
-			if (params.since) args.push("--since", params.since);
-			if (params.branch) args.push("--branch", params.branch);
-			if (typeof params.numResults === "number") args.push("-n", String(params.numResults));
-			if (params.dump) args.push("--dump", params.dump);
-			if (params.turns) args.push("--turns", params.turns);
-			if (params.query) args.push(params.query);
-
+			const args = buildArgs(params as PickbrainParams);
 			const result = await runPickbrain(args, ctx.cwd, sessionEnv(ctx), signal);
 			const text = renderResult(result);
 			return {
@@ -144,9 +182,9 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("pickbrain", {
-		description: "Run pickbrain with the current Pi session in the environment",
+		description: "Search prior Pi sessions with pickbrain (use flags to override)",
 		handler: async (args, ctx) => {
-			const argv = args.trim() ? args.trim().split(/\s+/) : [];
+			const argv = parseSlashArgs(args);
 			const result = await runPickbrain(argv, ctx.cwd, sessionEnv(ctx), ctx.signal);
 			pi.sendMessage(
 				{

--- a/skills/pickbrain-codex/SKILL.md
+++ b/skills/pickbrain-codex/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pickbrain
-description: Semantic search over past Claude Code and Codex conversations and memories. Use when the user wants to recall, find, or reference something from a previous coding session — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z".
+description: Semantic search over past Pi, Claude Code, and Codex conversations and memories. Use when the user wants to recall, find, or reference something from a previous coding session — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z".
 ---
 
 # Pickbrain — Semantic Search for AI Coding History
 
-Search past Claude Code and Codex conversations, memory files, and authored files using semantic search.
+Search past Pi, Claude Code, and Codex conversations, memory files, and authored files using semantic search.
 
 ## Usage
 
@@ -15,7 +15,7 @@ Run `pickbrain` with the user's query:
 pickbrain "$ARGUMENTS"
 ```
 
-Pickbrain automatically ingests new sessions, memories, and project config files (CLAUDE.md, AGENTS.md, and their @ references) before each search.
+Pickbrain automatically ingests new Pi/Claude/Codex sessions, memories, and project config files (CLAUDE.md, AGENTS.md, and their @ references) before each search.
 
 ## Interpreting Results
 

--- a/skills/pickbrain-pi/SKILL.md
+++ b/skills/pickbrain-pi/SKILL.md
@@ -1,58 +1,79 @@
 ---
 name: pickbrain
-description: Semantic search over past Pi, Claude Code, Codex, and Slack conversations and memories. Use when the user wants to recall, find, or reference something from a previous coding-agent session — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z".
+description: Recall and semantic search over previous Pi coding sessions. Use when the user wants to find, remember, or reference prior Pi work — e.g. "what did we discuss about X", "find the session where we fixed Y", "search my history for Z".
 ---
 
-# Pickbrain — Semantic Search for AI Coding History
+# Pickbrain — Recall for Pi
 
-Search past Pi, Claude Code, Codex, and Slack conversations, memory files, and authored files using semantic search.
+Search previous Pi sessions semantically and use the results to answer the user with citations/excerpts. Pickbrain can also search Claude Code, Codex, and Slack when explicitly requested, but in Pi it should default to Pi history.
 
 ## Preferred Pi Usage
 
-If the `pickbrain_search` tool is available, use it first. It passes the current Pi session to pickbrain so `current` and `excludeCurrent` filters work.
+If the `pickbrain_search` tool is available, use it first. It automatically:
+
+- defaults to `type: "pi"`
+- passes the current Pi session to pickbrain
+- suppresses ingest progress noise
+- limits results to a small useful set unless asked otherwise
 
 Examples:
-- Search all history: `pickbrain_search` with `{ "query": "auth middleware fix" }`
+
+- Search Pi history: `{ "query": "auth middleware fix" }`
 - Search current Pi session: `{ "query": "install target", "current": true }`
 - Exclude current Pi session: `{ "query": "dropbox witchcraft", "excludeCurrent": true }`
-- Restrict to Pi: `{ "query": "extension api", "type": "pi" }`
+- Search all coding agents: `{ "query": "extension api", "type": "pi,claude,codex" }`
+- Search everything, including Slack: `{ "query": "launch plan", "allSources": true }`
 - Dump a session: `{ "dump": "<session-id>", "turns": "2-4" }`
+
+## Slash Command
+
+The Pi extension also registers:
+
+```text
+/pickbrain <query>
+```
+
+This searches Pi sessions by default. Pass flags to override:
+
+```text
+/pickbrain --type pi,claude,codex auth middleware
+/pickbrain --dump <session-id> --turns 2-4
+```
 
 ## Bash Fallback
 
 If the tool is unavailable, run `pickbrain` via Bash:
 
 ```bash
-pickbrain "$ARGUMENTS"
+pickbrain --quiet --type pi "$ARGUMENTS"
 ```
 
-Pickbrain automatically ingests new Pi/Claude/Codex sessions, Slack conversations, memories, and project config files before each search.
+Pickbrain automatically ingests new sessions before each search. First run can take longer while building the local database.
 
 ## Interpreting Results
 
 Each result includes:
-- Timestamp and project directory (or channel for Slack)
-- Source: `pi`, `claude`, `codex`, or `slack`
-- Session ID and turn number for coding-agent sessions
-- Matching text from the conversation
+
+- timestamp and project directory
+- source: usually `pi`, or `claude`, `codex`, `slack` if requested
+- session ID and turn number
+- relevant matching text
 
 Present results as a concise summary and quote the most relevant excerpts. To dig deeper:
 
 ```bash
-pickbrain --dump <session-id> --turns <start>-<end>
+pickbrain --quiet --dump <session-id> --turns <start>-<end>
 ```
 
-## Useful Filters
+## Useful CLI Filters
 
 ```bash
-pickbrain --current "<query>"              # current calling session when detectable
-pickbrain --exclude-current "<query>"      # exclude current calling session
-pickbrain --session <session-id> "<query>" # one session
-pickbrain --type pi "<query>"              # only Pi sessions
-pickbrain --type claude,codex,pi "<query>" # coding sessions
-pickbrain --since 7d "<query>"             # recent history
-pickbrain --branch . "<query>"             # current git branch when available
-pickbrain -n 20 "<query>"                  # limit results
+pickbrain --quiet --type pi "<query>"       # only Pi sessions
+pickbrain --quiet --current "<query>"       # current calling session when detectable
+pickbrain --quiet --exclude-current "<query>"
+pickbrain --quiet --session <session-id> "<query>"
+pickbrain --quiet --since 7d "<query>"
+pickbrain --quiet -n 20 "<query>"
 ```
 
 ## Notes

--- a/skills/pickbrain-pi/SKILL.md
+++ b/skills/pickbrain-pi/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: pickbrain
+description: Semantic search over past Pi, Claude Code, Codex, and Slack conversations and memories. Use when the user wants to recall, find, or reference something from a previous coding-agent session — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z".
+---
+
+# Pickbrain — Semantic Search for AI Coding History
+
+Search past Pi, Claude Code, Codex, and Slack conversations, memory files, and authored files using semantic search.
+
+## Preferred Pi Usage
+
+If the `pickbrain_search` tool is available, use it first. It passes the current Pi session to pickbrain so `current` and `excludeCurrent` filters work.
+
+Examples:
+- Search all history: `pickbrain_search` with `{ "query": "auth middleware fix" }`
+- Search current Pi session: `{ "query": "install target", "current": true }`
+- Exclude current Pi session: `{ "query": "dropbox witchcraft", "excludeCurrent": true }`
+- Restrict to Pi: `{ "query": "extension api", "type": "pi" }`
+- Dump a session: `{ "dump": "<session-id>", "turns": "2-4" }`
+
+## Bash Fallback
+
+If the tool is unavailable, run `pickbrain` via Bash:
+
+```bash
+pickbrain "$ARGUMENTS"
+```
+
+Pickbrain automatically ingests new Pi/Claude/Codex sessions, Slack conversations, memories, and project config files before each search.
+
+## Interpreting Results
+
+Each result includes:
+- Timestamp and project directory (or channel for Slack)
+- Source: `pi`, `claude`, `codex`, or `slack`
+- Session ID and turn number for coding-agent sessions
+- Matching text from the conversation
+
+Present results as a concise summary and quote the most relevant excerpts. To dig deeper:
+
+```bash
+pickbrain --dump <session-id> --turns <start>-<end>
+```
+
+## Useful Filters
+
+```bash
+pickbrain --current "<query>"              # current calling session when detectable
+pickbrain --exclude-current "<query>"      # exclude current calling session
+pickbrain --session <session-id> "<query>" # one session
+pickbrain --type pi "<query>"              # only Pi sessions
+pickbrain --type claude,codex,pi "<query>" # coding sessions
+pickbrain --since 7d "<query>"             # recent history
+pickbrain --branch . "<query>"             # current git branch when available
+pickbrain -n 20 "<query>"                  # limit results
+```
+
+## Notes
+
+- The database lives at `~/.pickbrain/pickbrain.db`.
+- Results are ranked by semantic similarity and may not contain exact query words.
+- For best Pi integration, keep the Pi extension installed in `~/.pi/agent/extensions/pickbrain/`.

--- a/skills/pickbrain/SKILL.md
+++ b/skills/pickbrain/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pickbrain
-description: Semantic search over past Claude Code conversations, memories, and Slack messages. Use when the user wants to recall, find, or reference something from a previous Claude session or Slack conversation — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z", "what did someone say about X in Slack".
+description: Semantic search over past Pi, Claude Code, Codex, and Slack conversations, memories, and authored files. Use when the user wants to recall, find, or reference something from a previous coding-agent session or Slack conversation — e.g. "what did we discuss about X", "find that conversation where we fixed Y", "search my history for Z", "what did someone say about X in Slack".
 allowed-tools: Bash
 ---
 
 # Pickbrain — Semantic Search for Claude History and Slack
 
-Search past Claude Code conversations, Codex sessions, Slack messages, memory files, and authored files using semantic search.
+Search past Pi sessions, Claude Code conversations, Codex sessions, Slack messages, memory files, and authored files using semantic search.
 
 ## Installation
 
@@ -28,13 +28,13 @@ Run `pickbrain` via Bash with the user's query:
 pickbrain "$ARGUMENTS"
 ```
 
-Pickbrain automatically ingests new Claude/Codex sessions, Slack conversations (from the desktop app's local IndexedDB), memories, and project config files before each search.
+Pickbrain automatically ingests new Pi/Claude/Codex sessions, Slack conversations (from the desktop app's local IndexedDB), memories, and project config files before each search.
 
 ## Interpreting Results
 
 Each result includes:
 - **Timestamp** and **project directory** (or **channel name** for Slack results)
-- **Source** — `claude`, `codex`, or `slack`
+- **Source** — `pi`, `claude`, `codex`, or `slack`
 - **Session ID** and **turn number** (Claude/Codex) or **channel + thread ID** (Slack)
 - **Matching text** — the relevant chunk from the conversation
 
@@ -96,7 +96,7 @@ pickbrain --since 7d "<query>"
 pickbrain --since 2w "<query>"
 ```
 
-To filter by source type (claude, codex, slack):
+To filter by source type (pi, claude, codex, slack):
 
 ```bash
 pickbrain --type slack "<query>"


### PR DESCRIPTION
## Summary

Adds Pi support to `pickbrain` while keeping the existing Claude Code, Codex, and Slack support intact.

- Index Pi sessions from `~/.pi/agent/sessions/**/*.jsonl`
- Add `pi` as a `--type` source filter and display label
- Support Pi session search, dump, and resume (`pi --session <id>`)
- Add active-session environment detection for Pi integrations
- Install a Pi skill and Pi extension via `make pickbrain-install`
- Improve Pi UX: extension defaults to Pi sessions, limits results, and uses `--quiet` to hide ingest progress noise

## Testing

```bash
cargo test --release --example pickbrain --features t5-quantized,metal,progress,embed-assets
```

## License

Submitted under the repository's Apache-2.0 license.
