### PR TITLE
Add Python bindings via PyO3/maturin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3.20.0"
 
 napi = { version = "3.2.2", optional = true }
 napi-derive = { version = "3.2.2", optional = true }
+pyo3 = { version = "0.23", optional = true, features = ["extension-module", "abi3-py38"] }
 once_cell = "1.21.3"
 lru = "0.18.0"
 tracing = "0.1.41"
@@ -84,6 +85,7 @@ napi-build = "2.2.3"
 #default = ["t5-quantized"]
 #default = ["t5-openvino"]
 napi = ["dep:napi", "dep:napi-derive"]
+python = ["dep:pyo3"]
 t5-quantized = []
 t5-openvino = ["dep:openvino"]
 embed-assets = []

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,14 @@ ifeq ($(UNAME_S),Darwin)
     # Apple Silicon: Metal GPU + Accelerate BLAS
     CLI_FEATURES := t5-quantized,metal,progress
     NAPI_FEATURES := t5-quantized,metal,napi
+    PYTHON_FEATURES := t5-quantized,metal,python
     RUSTFLAGS_EXTRA :=
     TARGET := aarch64-apple-darwin
   else
     # Intel Mac: CPU-only with FBGEMM + hybrid-dequant
     CLI_FEATURES := t5-quantized,fbgemm,hybrid-dequant,progress
     NAPI_FEATURES := t5-quantized,fbgemm,hybrid-dequant,napi
+    PYTHON_FEATURES := t5-quantized,fbgemm,hybrid-dequant,python
     RUSTFLAGS_EXTRA := -C target-feature=+avx2,+fma
     TARGET := x86_64-apple-darwin
   endif
@@ -26,9 +28,17 @@ else ifeq ($(UNAME_S),Linux)
   ifneq ($(NVCC),)
     CLI_FEATURES := t5-quantized,cuda,progress
     NAPI_FEATURES := t5-quantized,cuda,napi
+    PYTHON_FEATURES := t5-quantized,cuda,python
+  else ifeq ($(UNAME_M),aarch64)
+    # Linux ARM (Graviton, Pi, Ampere): fbgemm/hybrid-dequant are x86-only
+    CLI_FEATURES := t5-quantized,progress
+    NAPI_FEATURES := t5-quantized,napi
+    PYTHON_FEATURES := t5-quantized,python
   else
+    # Linux x86_64 CPU-only
     CLI_FEATURES := t5-quantized,fbgemm,hybrid-dequant,progress
     NAPI_FEATURES := t5-quantized,fbgemm,hybrid-dequant,napi
+    PYTHON_FEATURES := t5-quantized,fbgemm,hybrid-dequant,python
   endif
   PICKBRAIN_FEATURES := $(CLI_FEATURES),embed-assets
   RUSTFLAGS_EXTRA :=
@@ -163,6 +173,14 @@ run: module
 	ln -sf target/release/warp-macos-universal.node warp.node
 	node index.cjs
 
+python-wheel: prereqs download
+	@command -v maturin >/dev/null 2>&1 || { echo "maturin not found — run: pip install maturin" >&2; exit 1; }
+	maturin build --release $(BUILD_TARGET) --features $(PYTHON_FEATURES)
+
+python-dev: prereqs download
+	@command -v maturin >/dev/null 2>&1 || { echo "maturin not found — run: pip install maturin" >&2; exit 1; }
+	maturin develop --features $(PYTHON_FEATURES)
+
 distclean:
 	rm -rf target env html xtr-base-en openvino_model
 	rm -f warp-cli warp.node pickbrain Cargo.lock lcov.info output.txt
@@ -179,4 +197,4 @@ distclean:
 	fi
 	rm -rf .make-stamps .stamp* stamp-* *.stamp */.stamp* */*.stamp */stamp-*
 
-.PHONY: prereqs download ovdownload build buildemb warp-cli pickbrain pickbrain-install module macintel winintel win test bench nfcorpus nfcorpus-score run distclean
+.PHONY: prereqs download ovdownload build buildemb warp-cli pickbrain pickbrain-install module macintel winintel win test bench nfcorpus nfcorpus-score run python-wheel python-dev distclean

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Other flags:
 - `fbgemm` -- fbgemm-rs packed GEMM (bf16 weights, faster on x86)
 - `hybrid-dequant` -- F32 attention + Q4K FFN with fused gated-gelu (x86, requires `fbgemm`)
 - `napi` -- Node.js native module via napi-rs
+- `python` -- Python extension module via PyO3/maturin
 - `embed-assets` -- bake weights into binary
 - `progress` -- progress bars for CLI
 
@@ -104,6 +105,74 @@ Platform-specific recommended features (these are what `make` uses automatically
 - **Apple Silicon**: `t5-quantized,metal`
 - **Intel Mac (x86_64)**: `t5-quantized,fbgemm,hybrid-dequant`
 - **Intel Windows (x86_64)**: `t5-openvino,fbgemm`
+- **Linux x86_64 (CPU)**: `t5-quantized,fbgemm,hybrid-dequant`
+- **Linux x86_64 (CUDA)**: `t5-quantized,cuda`
+- **Linux ARM (Graviton, Pi, Ampere)**: `t5-quantized` (`fbgemm`/`hybrid-dequant` are x86-only)
+
+## Using as a Python module ##
+
+Requires [maturin](https://github.com/PyO3/maturin):
+
+```
+pip install maturin
+```
+
+Build a wheel for your current platform (auto-selects the right backend features):
+
+```
+make python-wheel
+pip install target/wheels/witchcraft-*.whl
+```
+
+Or, inside a virtualenv, install directly for development:
+
+```
+make python-dev
+```
+
+The Makefile picks the correct feature set automatically (`metal` on Apple Silicon,
+`fbgemm,hybrid-dequant` on Intel, `cuda` on Linux with a GPU). The wheel works on
+Python 3.8+, including 3.14+.
+
+To run the Python test suite after installing the wheel:
+
+```
+pip install pytest
+pytest tests/test_witchcraft.py
+```
+
+Tests that exercise the embedder (search, score, add, etc.) are skipped unless
+model assets are present. Run `make download` first to enable them.
+
+Then in Python:
+
+```python
+import witchcraft
+
+wc = witchcraft.Witchcraft('/path/to/db.sqlite', '/path/to/assets')
+
+# Add documents (fire-and-forget, processed by background thread)
+wc.add('550e8400-e29b-41d4-a716-446655440000',
+       '2024-01-15T10:00:00Z',
+       '{"source": "dropbox"}',
+       'The document text goes here')
+
+# Trigger embedding + index build
+wc.index()
+
+# Hybrid semantic + BM25 search
+results = wc.search('does milk intake cause acne?', threshold=0.3, top_k=5)
+for r in results:
+    print(r['score'], r['body'])
+
+# Score individual sentences against a query
+scores = wc.score('acne and diet', ['milk causes acne', 'exercise helps skin'])
+
+# Shut down the background indexer cleanly
+wc.shutdown()
+```
+
+`search` returns a list of dicts with keys: `score`, `metadata`, `body`, `idx`, `date`.
 
 ## Using as Node module ##
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    napi_build::setup(); // enables N-API compatibility
+    if std::env::var("CARGO_FEATURE_NAPI").is_ok() {
+        napi_build::setup();
+    }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "witchcraft"
+version = "0.1.2"
+description = "Semantic search with hybrid dense/sparse retrieval"
+requires-python = ">=3.8"
+license = {text = "Apache-2.0"}
+
+[tool.maturin]
+features = ["python"]
+module-name = "witchcraft"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ use sql_generator::build_filter_sql_and_params;
 #[allow(dead_code)]
 mod napi;
 
+#[cfg(feature = "python")]
+mod python;
+
 use anyhow::Result;
 use candle_core::{DType, Device, IndexOp, Tensor, D};
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,286 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc};
+use std::thread;
+
+enum IndexJob {
+    Add {
+        uuid: uuid::Uuid,
+        date: Option<iso8601_timestamp::Timestamp>,
+        metadata: String,
+        body: String,
+        lengths: Option<Vec<usize>>,
+    },
+    Remove {
+        uuid: uuid::Uuid,
+    },
+    Index,
+    Clear,
+    Shutdown,
+}
+
+struct Reader {
+    db: crate::DB,
+    embedder: Arc<crate::Embedder>,
+    cache: crate::EmbeddingsCache,
+}
+
+impl Reader {
+    fn new(db: crate::DB, embedder: Arc<crate::Embedder>) -> Self {
+        Self {
+            db,
+            embedder,
+            cache: crate::EmbeddingsCache::new(16),
+        }
+    }
+
+    fn search(
+        &mut self,
+        q: &str,
+        threshold: f32,
+        top_k: usize,
+    ) -> Vec<(f32, String, Vec<String>, u32, String)> {
+        crate::search(
+            &self.db,
+            &self.embedder,
+            &mut self.cache,
+            q,
+            threshold,
+            top_k,
+            true,
+            None,
+        )
+        .unwrap_or_default()
+    }
+
+    fn score(&mut self, q: &str, sentences: &[String]) -> Vec<f32> {
+        crate::score_query_sentences(&self.embedder, &mut self.cache, &q.to_string(), sentences)
+            .unwrap_or_default()
+    }
+}
+
+/// Semantic search index with hybrid dense/sparse retrieval.
+///
+/// Args:
+///     db_name: Path to the SQLite database file (created if absent).
+///     assets: Directory containing model weights and tokenizer files.
+#[pyclass]
+pub struct Witchcraft {
+    reader: Reader,
+    tx: mpsc::Sender<IndexJob>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+// Safe: Reader (which owns a rusqlite::Connection, a !Send/!Sync type) is only
+// ever accessed from the Python thread while the GIL is held, ensuring
+// exclusive single-threaded access.  The indexer thread creates its own
+// separate DB connection and never shares state with Reader.
+unsafe impl Send for Witchcraft {}
+unsafe impl Sync for Witchcraft {}
+
+impl Drop for Witchcraft {
+    fn drop(&mut self) {
+        let _ = self.tx.send(IndexJob::Shutdown);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+#[pymethods]
+impl Witchcraft {
+    #[new]
+    fn new(db_name: String, assets: String) -> PyResult<Self> {
+        let db_path = PathBuf::from(&db_name);
+        let assets_path = PathBuf::from(&assets);
+
+        // Create the write DB first so the file exists before DB::new_reader opens it.
+        let mut write_db = crate::DB::new(db_path.clone())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+
+        // Load the embedder once and share it between the reader and indexer thread.
+        let device = crate::make_device();
+        let embedder = Arc::new(
+            crate::Embedder::new(&device, &assets_path)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?,
+        );
+
+        let reader_db = crate::DB::new_reader(db_path)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let reader = Reader::new(reader_db, Arc::clone(&embedder));
+
+        let thread_embedder = Arc::clone(&embedder);
+        let (tx, rx) = mpsc::channel::<IndexJob>();
+        let handle = thread::spawn(move || {
+            while let Ok(job) = rx.recv() {
+                match job {
+                    IndexJob::Shutdown => break,
+                    IndexJob::Clear => {
+                        write_db.clear();
+                    }
+                    IndexJob::Add {
+                        uuid,
+                        date,
+                        metadata,
+                        body,
+                        lengths,
+                    } => {
+                        if let Err(e) = write_db.add_doc(&uuid, date, &metadata, &body, lengths) {
+                            tracing::warn!("witchcraft: add_doc failed: {e}");
+                        }
+                    }
+                    IndexJob::Remove { uuid } => {
+                        if let Err(e) = write_db.remove_doc(&uuid) {
+                            tracing::warn!("witchcraft: remove_doc failed: {e}");
+                        }
+                    }
+                    IndexJob::Index => {
+                        loop {
+                            match crate::embed_chunks(&mut write_db, &thread_embedder, Some(10)) {
+                                Ok(0) => break,
+                                Err(e) => {
+                                    tracing::warn!("witchcraft: embed_chunks failed: {e}");
+                                    break;
+                                }
+                                Ok(_) => {}
+                            }
+                        }
+                        if let Err(e) = crate::index_chunks(&mut write_db, &device) {
+                            tracing::warn!("witchcraft: index_chunks failed: {e}");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            reader,
+            tx,
+            handle: Some(handle),
+        })
+    }
+
+    /// Search the index.
+    ///
+    /// Args:
+    ///     q: Query string.
+    ///     threshold: Minimum similarity score (0–1). Defaults to 0.3.
+    ///     top_k: Maximum results to return. Defaults to 10.
+    ///
+    /// Returns:
+    ///     List of dicts with keys: score, metadata, body, idx, date.
+    #[pyo3(signature = (q, threshold=0.3, top_k=10))]
+    fn search(
+        &mut self,
+        py: Python<'_>,
+        q: String,
+        threshold: f64,
+        top_k: usize,
+    ) -> PyResult<Vec<PyObject>> {
+        let results = self.reader.search(&q, threshold as f32, top_k);
+        results
+            .into_iter()
+            .map(|(score, metadata, bodies, idx, date)| {
+                let sub = (idx as usize).min(bodies.len().saturating_sub(1));
+                let body = bodies.get(sub).cloned().unwrap_or_default();
+                let dict = PyDict::new(py);
+                dict.set_item("score", score as f64)?;
+                dict.set_item("metadata", &metadata)?;
+                dict.set_item("body", &body)?;
+                dict.set_item("idx", idx)?;
+                dict.set_item("date", &date)?;
+                Ok(dict.into_any().unbind())
+            })
+            .collect()
+    }
+
+    /// Score how well each sentence matches the query.
+    ///
+    /// Args:
+    ///     q: Query string.
+    ///     sentences: Candidate sentences to score.
+    ///
+    /// Returns:
+    ///     List of similarity scores (one per sentence, 0–1).
+    fn score(&mut self, q: String, sentences: Vec<String>) -> PyResult<Vec<f32>> {
+        Ok(self.reader.score(&q, &sentences))
+    }
+
+    /// Add or update a document in the index.
+    ///
+    /// Args:
+    ///     uuid: Stable identifier for the document (UUID string).
+    ///     date: ISO 8601 timestamp (e.g. "2024-01-15T10:00:00Z").
+    ///     metadata: Arbitrary JSON metadata string.
+    ///     body: Document text.
+    ///     lengths: Optional list of codepoint lengths for pre-split chunks.
+    #[pyo3(signature = (uuid, date, metadata, body, lengths=None))]
+    fn add(
+        &self,
+        uuid: String,
+        date: String,
+        metadata: String,
+        body: String,
+        lengths: Option<Vec<u32>>,
+    ) -> PyResult<()> {
+        let uuid = uuid::Uuid::parse_str(&uuid)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        let date = iso8601_timestamp::Timestamp::parse(&date).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid ISO 8601 date: {date}"))
+        })?;
+        let lengths = lengths.map(|v| v.into_iter().map(|l| l as usize).collect());
+        if self
+            .tx
+            .send(IndexJob::Add {
+                uuid,
+                date: Some(date),
+                metadata,
+                body,
+                lengths,
+            })
+            .is_err()
+        {
+            tracing::warn!("witchcraft: add() dropped — indexer thread has exited");
+        }
+        Ok(())
+    }
+
+    /// Remove a document by UUID.
+    fn remove(&self, uuid: String) -> PyResult<()> {
+        let uuid = uuid::Uuid::parse_str(&uuid)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        if self.tx.send(IndexJob::Remove { uuid }).is_err() {
+            tracing::warn!("witchcraft: remove() dropped — indexer thread has exited");
+        }
+        Ok(())
+    }
+
+    /// Trigger embedding and index-building for any pending documents.
+    fn index(&self) {
+        if self.tx.send(IndexJob::Index).is_err() {
+            tracing::warn!("witchcraft: index() dropped — indexer thread has exited");
+        }
+    }
+
+    /// Clear all documents from the index.
+    fn clear(&self) {
+        if self.tx.send(IndexJob::Clear).is_err() {
+            tracing::warn!("witchcraft: clear() dropped — indexer thread has exited");
+        }
+    }
+
+    /// Shut down the background indexer and wait for it to finish.
+    fn shutdown(&mut self) {
+        let _ = self.tx.send(IndexJob::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[pymodule]
+fn witchcraft(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Witchcraft>()?;
+    Ok(())
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -74,8 +74,8 @@ pub struct Witchcraft {
 
 // Safe: Reader (which owns a rusqlite::Connection, a !Send/!Sync type) is only
 // ever accessed from the Python thread while the GIL is held, ensuring
-// exclusive single-threaded access.  The indexer thread creates its own
-// separate DB connection and never shares state with Reader.
+// exclusive single-threaded access.  The indexer thread owns a separate
+// write connection to the same file and never shares state with Reader.
 unsafe impl Send for Witchcraft {}
 unsafe impl Sync for Witchcraft {}
 

--- a/tests/test_witchcraft.py
+++ b/tests/test_witchcraft.py
@@ -1,0 +1,160 @@
+"""
+Smoke tests for the witchcraft Python extension module.
+
+Run after building and installing the wheel:
+    make python-wheel
+    pip install target/wheels/witchcraft-*.whl
+    pytest tests/test_witchcraft.py
+
+Tests marked 'needs_assets' require model weights in assets/:
+    make download
+    pytest tests/test_witchcraft.py
+"""
+
+import os
+import tempfile
+import pytest
+import witchcraft
+
+ASSETS = os.path.join(os.path.dirname(__file__), '..', 'assets')
+
+needs_assets = pytest.mark.skipif(
+    not os.path.exists(os.path.join(ASSETS, 'config.json')),
+    reason="model assets not downloaded — run 'make download'",
+)
+
+FACTS = [
+    "Octopuses have three hearts and blue blood.",
+    "A group of flamingos is called a flamboyance.",
+    "Honey never spoils; archaeologists have found 3000-year-old edible honey.",
+    "There is a lake in Australia that stays bright pink regardless of conditions.",
+    "Sharks existed before trees.",
+]
+
+
+# --- Error propagation (Witchcraft::new fails fast on bad paths) ---
+
+def test_bad_db_path_raises():
+    with pytest.raises(RuntimeError):
+        witchcraft.Witchcraft('/nonexistent/path/db.sqlite', ASSETS)
+
+
+def test_bad_assets_raises():
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(RuntimeError):
+            witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), '/nonexistent/assets')
+
+
+# --- Drop / shutdown ---
+
+@needs_assets
+def test_drop_without_shutdown_does_not_hang():
+    """Drop impl should join the indexer thread cleanly without explicit shutdown()."""
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        del wc  # triggers Drop
+
+
+@needs_assets
+def test_explicit_shutdown_is_idempotent():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        wc.shutdown()
+        # second shutdown (or Drop after shutdown) must not panic
+        del wc
+
+
+# --- Round-trip: add / index / search / score ---
+
+@needs_assets
+def test_search_returns_results():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        for i, body in enumerate(FACTS):
+            wc.add(
+                f'00000000-0000-0000-0000-{i:012d}',
+                '2024-01-01T00:00:00Z',
+                '{}',
+                body,
+            )
+        wc.index()
+        wc.shutdown()
+
+        # Re-open for search (new instance, same DB)
+        wc2 = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        results = wc2.search('group of birds called a flamboyance', threshold=0.3, top_k=5)
+        wc2.shutdown()
+
+    assert isinstance(results, list)
+    assert len(results) >= 1
+    top = results[0]
+    assert set(top.keys()) == {'score', 'metadata', 'body', 'idx', 'date'}
+    assert isinstance(top['score'], float)
+    assert 0.0 <= top['score'] <= 1.0
+
+
+@needs_assets
+def test_score_ranks_relevant_sentence_highest():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        sentences = [
+            "Flamingos are pink birds that live in flocks.",
+            "Honey bees produce honey from flower nectar.",
+            "Sharks are ancient fish that predate trees.",
+        ]
+        scores = wc.score('a group of flamingos', sentences)
+        wc.shutdown()
+
+    assert len(scores) == len(sentences)
+    assert all(isinstance(s, float) for s in scores)
+    assert scores[0] == max(scores), "flamingo sentence should score highest"
+
+
+@needs_assets
+def test_remove_doc():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        uid = '00000000-0000-0000-0000-000000000001'
+        wc.add(uid, '2024-01-01T00:00:00Z', '{}', FACTS[1])
+        wc.remove(uid)
+        wc.index()
+        wc.shutdown()
+
+
+@needs_assets
+def test_clear():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        for i, body in enumerate(FACTS):
+            wc.add(f'00000000-0000-0000-0000-{i:012d}', '2024-01-01T00:00:00Z', '{}', body)
+        wc.clear()
+        wc.shutdown()
+
+
+# --- Input validation ---
+
+@needs_assets
+def test_add_invalid_uuid_raises():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        with pytest.raises(ValueError):
+            wc.add('not-a-uuid', '2024-01-01T00:00:00Z', '{}', 'body')
+        wc.shutdown()
+
+
+@needs_assets
+def test_add_invalid_date_raises():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        with pytest.raises(ValueError):
+            wc.add('550e8400-e29b-41d4-a716-446655440000', 'not-a-date', '{}', 'body')
+        wc.shutdown()
+
+
+@needs_assets
+def test_remove_invalid_uuid_raises():
+    with tempfile.TemporaryDirectory() as d:
+        wc = witchcraft.Witchcraft(os.path.join(d, 'test.sqlite'), ASSETS)
+        with pytest.raises(ValueError):
+            wc.remove('bad-uuid')
+        wc.shutdown()


### PR DESCRIPTION
Exposes Witchcraft as a Python extension module using PyO3. Each instance owns an independent reader connection (search/score) and a background indexer thread (add/remove/index/clear), mirroring the napi module's architecture.

Key details:
- src/python.rs: new PyO3 module behind the `python` feature flag
- build.rs: napi_build::setup() is now conditional on CARGO_FEATURE_NAPI so non-napi builds don't set conflicting linker flags
- pyo3 uses abi3-py38 stable ABI; single wheel runs on Python 3.8–3.14+
- Makefile: python-wheel / python-dev targets with auto-detected platform features; Linux aarch64 guard added across CLI/napi/python feature sets to avoid x86-only fbgemm/hybrid-dequant on ARM
- pyproject.toml added for maturin; platform features come from Makefile
- tests/test_witchcraft.py: smoke tests with @needs_assets skip marker for tests requiring downloaded model weights
- README: Python build instructions, platform matrix, test instructions

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>